### PR TITLE
Fix the layout of the PlantGrowth panel.

### DIFF
--- a/src/components/basepanel/BasePanel.vue
+++ b/src/components/basepanel/BasePanel.vue
@@ -80,17 +80,6 @@ export default {
         font-weight: 600;
     }
 
-    .plant-wrapper{
-        display:grid;
-        grid-template-rows: repeat(auto-fill,minmax(32px,1fr));
-        grid-template-columns: minmax(0px,1fr);
-        grid-row-gap: 4px;
-        font-size: 14px;
-
-        *{
-            margin: auto 0px;
-        }
-    }
 
 
 

--- a/src/components/dashboard/Main.vue
+++ b/src/components/dashboard/Main.vue
@@ -147,36 +147,6 @@ export default {
         font-size: 14px;
         font-weight: 200;
     }
-
-    .line-item{
-        font-size: 18px;
-        font-weight: 600;
-    }
-
-    .plant-wrapper{
-        display:grid;
-        grid-template-rows: repeat(auto-fill,minmax(32px,1fr));
-        grid-template-columns: minmax(0px,1fr);
-        grid-row-gap: 4px;
-        font-size: 14px;
-
-        *{
-            margin: auto 0px;
-        }
-    }
-
-    .plant-row-wrapper{
-        display:grid;
-        grid-template-columns: minmax(0px,1fr) minmax(0px,1fr) minmax(0px,1fr);
-        grid-column-gap: 8px;
-    }
-
-    .section-title{
-        font-size: 14px;
-        text-decoration: underline;
-        font-weight: 200;
-    }
-
     .gauge-wrapper{
         display:grid;
         grid-template-rows: minmax(0px,1fr) 24px;

--- a/src/components/panels/PlantGrowth.vue
+++ b/src/components/panels/PlantGrowth.vue
@@ -1,22 +1,24 @@
 <template>
-    <div class='plant-wrapper'>
-        <section class='plant-row-wrapper'>
-            <span class='section-title'>Plant Species</span>
-            <span class='section-title' style="text-align:center;">Qty</span>
-            <span class='section-title' style="text-align:right;">% of Growth</span>
-        </section>
-        <section class='plant-row-wrapper' v-for="(item,index) in getConfiguration.plantSpecies" :key="index">
-            <div class='line-item' >
-                {{stringFormatter(getConfiguration.plantSpecies[index].type)}}
-            </div>
-            <div class='line-item' style="text-align:center;">
-                {{getConfiguration.plantSpecies[index].amount}}
-            </div>
-            <div class='line-item' style="text-align:right;">
-                {{getTotalAgentMass(getStepBuffer.current)[getConfiguration.plantSpecies[index].type].value + "%"}}
-            </div>
-        </section>
-    </div>
+  <section class="plant-growth-wrapper">
+      <table class="plant-growth">
+          <tr>
+              <th>Plant Species</th>
+              <th>Qty</th>
+              <th>% of Growth</th>
+          </tr>
+          <tr v-for="(item,index) in getConfiguration.plantSpecies" :key="index">
+              <td >
+                  {{stringFormatter(getConfiguration.plantSpecies[index].type)}}
+              </td>
+              <td>
+                  {{getConfiguration.plantSpecies[index].amount}}
+              </td>
+              <td>
+                  {{getTotalAgentMass(getStepBuffer.current)[getConfiguration.plantSpecies[index].type].value.toExponential(3) + "%"}}
+              </td>
+          </tr>
+      </table>
+  </section>
 </template>
 
 
@@ -45,9 +47,25 @@ export default {
 
 
 <style lang="scss" scoped>
-    .plant-row-wrapper{
-        display:grid;
-        grid-template-columns: minmax(0px,1fr) minmax(0px,1fr) minmax(0px,1fr);
-        grid-column-gap: 8px;
-    }
+.plant-growth-wrapper {
+    overflow-y: auto;
+}
+.plant-growth {
+    width: 100%;
+}
+.plant-growth th,
+.plant-growth td {
+    text-align: center;
+    padding: 2px 0;
+}
+
+.plant-growth th:first-child,
+.plant-growth td:first-child {
+    text-align: left;
+}
+.plant-growth th:last-child,
+.plant-growth td:last-child {
+    text-align: right;
+}
+
 </style>


### PR DESCRIPTION
This PR fixes/restores the layout of the PlantGrowth panel:
* the 3 columns are now styled and aligned
* the growth is displayed in exponential notation with 3 digits after the decimal point
* the HTML now uses a table instead of divs
* if the elements don't fit, a scrollbar will appear

![plant-growth-00](https://user-images.githubusercontent.com/25624924/62186703-6fc9a480-b367-11e9-8884-5cb2b1727e1b.png)

@gschoberth : any reason not to use a table instead of divs?
@kstaats : do you think forcing exponential notation and 3 digits after the decimal point is ok?