### PR TITLE
#13: import and use Open Sans and Roboto.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,9 +18,11 @@ export default {
 
 
 <style lang="scss">
+  /* Use Roboto for the dashboard, Open Sans for everything else */
+  @import url('https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i|Roboto:100,300,400,500,700,900&display=swap');
+
   body{
     font-family: "Open Sans", sans-serif;
-
     padding: 0px;
     margin: 0px;
     background-image:url('./assets/mars-bg.jpg');

--- a/src/components/configuration/Reference.vue
+++ b/src/components/configuration/Reference.vue
@@ -304,6 +304,7 @@ export default {
     }
 
     .reference-item{
+        font-family: "Open Sans", sans-serif;
         margin-right: 16px;
     }
 

--- a/src/components/dashboard/Main.vue
+++ b/src/components/dashboard/Main.vue
@@ -88,6 +88,7 @@ export default {
 
 
     .dashboard-view-wrapper{
+        font-family: "Roboto", sans-serif;
         width:100%;
         height:100%;
         padding: 16px;

--- a/src/components/entry/Welcome.vue
+++ b/src/components/entry/Welcome.vue
@@ -77,6 +77,7 @@ export default {
     }
 
     .welcome-paragraph{
+        font-family: "Open Sans", sans-serif;
         &:not(:last-of-type){
             margin-bottom:12px;
         }


### PR DESCRIPTION
I think Roboto works well for the dashboard since it's the most compact and we have lot of data to display there.
For the rest I just used Open Sans, but we could use Montserrat for the titles if you think it looks better.  If we do, we have to decide which titles will use it and be consistent.