### PR TITLE
Fix gh config graph

### DIFF
--- a/src/components/configuration/Graphs.vue
+++ b/src/components/configuration/Graphs.vue
@@ -3,7 +3,7 @@ similar functionality to that of the reference wiki. Table of contents to select
 -->
 
 <template>
-        <GreenhouseDoughnut class="greenhouse-config-graph" :class="{'visible': getActiveForm === 'Greenhouse' || getActiveForm === 'Finalize'}" :id="'gh-config-canvas-'+ canvasNumber"/>
+        <GreenhouseDoughnut class="greenhouse-config-graph" v-if="getActiveReference === 'Graphs' && (getActiveForm === 'Greenhouse' || getActiveForm === 'Finalize')" :id="'gh-config-canvas-'+ canvasNumber"/>
 </template>
 
 <script>
@@ -17,7 +17,7 @@ export default {
         'GreenhouseDoughnut':GreenhouseDoughnut
     },
     computed:{
-        ...mapGetters('wizard',['getActiveForm']),
+        ...mapGetters('wizard',['getActiveReference','getActiveForm']),
     },
 }
 </script>
@@ -27,11 +27,5 @@ export default {
         width: 100%;
         height: 100%;
         position:relative;
-    }
-    .greenhouse-config-graph {
-        display: none !important;
-    }
-    .greenhouse-config-graph.visible {
-        display: block !important;
     }
 </style>

--- a/src/components/graphs/GreenhouseDoughnut.vue
+++ b/src/components/graphs/GreenhouseDoughnut.vue
@@ -35,7 +35,6 @@ export default {
             backgroundColor:["#e6194b", "#3cb44b", "#ffe119", "#4363d8", "#f58231", "#911eb4", "#46f0f0", "#f032e6", "#bcf60c", "#fabebe", "#008080", "#e6beff", "#9a6324", "#fffac8", "#800000", "#aaffc3", "#808000", "#ffd8b1", "#000075", "#808080", "#ffffff", "#000000"]
         }
     },
-
     computed:{
         ...mapGetters('wizard',['getConfiguration']),
         ...mapGetters('dashboard',['getStepBuffer']),
@@ -84,13 +83,21 @@ export default {
             return values
         },
         updateChart: function(){
-            console.log('updateChart called')
             const {greenhouse,plantSpecies} = this.getConfiguration
             const {data,labels} = this.greenhouseConfiguration()
-            this.chart.data.labels = labels
-            this.chart.data.datasets[0].data.pop()
-            this.chart.data.datasets[0].data = data
-            this.chart.options.elements.centerText.text = data[0] + " m³ / " + this.greenhouseSize[greenhouse.type] + " m³"
+            this.chart.data.labels = labels  // labels are always visible
+            // only show the text if the greenhouse type is none
+            if (greenhouse.type === 'none') {
+                this.chart.data.datasets[0].data = []
+                var text = 'No Greenhouse Type Selected'
+            }
+            // otherwise show both the doughnut and the text
+            else {
+                this.chart.data.datasets[0].data.pop()
+                this.chart.data.datasets[0].data = data
+                var text = data[0] + " m³ / " + this.greenhouseSize[greenhouse.type] + " m³"
+            }
+            this.chart.options.elements.centerText.text = text
             this.chart.update()
         },
         //Format the plant names before displaying them.
@@ -148,7 +155,7 @@ export default {
                         borderWidth: 0
                     },
                     centerText:{
-                        text:"Greenhouse Doughnut Calculating",
+                        text: '',
                     }
                 },
                 legend:{
@@ -191,6 +198,7 @@ export default {
                 }
             }]
         })
+    this.updateChart()  // this will set the center text and other things
     }
 }
 

--- a/src/store/modules/wizard.js
+++ b/src/store/modules/wizard.js
@@ -120,7 +120,6 @@ export default{
             }
         },
         SETACTIVEFORMINDEX:(state,value)=>{
-            console.log('setting activeFormIndex to', value)
             state.activeFormIndex = value
         },
         SETACTIVEREFERENCE:(state,value)=>{
@@ -132,7 +131,6 @@ export default{
             //It is redundant for the table of contents navigation.
         },
         RESETCONFIG: function(state) {
-            console.log('RESETCONFIG called')
             state.configuration = {
                 location: "none",
                 duration: {type:"none", amount:'0', units:"none"},

--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -141,7 +141,6 @@ export default {
         //If the active form changes update the activeForm variable with the one at the formIndex
         getActiveForm:{
             handler:function(){
-                console.log('getActiveForm changed')
                 this.activeForm = this.getActiveForm
             },
             deep:true
@@ -150,7 +149,6 @@ export default {
         //Mostly used for when either the buttons or the select menu or used to navigate
         formIndex:{
             handler:function(){
-                console.log('SETACTIVEFORMINDEX is', this.SETACTIVEFORMINDEX)
                 this.SETACTIVEFORMINDEX(this.formIndex)
                 this.activeForm = this.getActiveForm
             }


### PR DESCRIPTION
Even though fixing the id was enough to make the graph show up, there were a series of other things that weren't working properly.

In order to make it work, I:
* renderer the doughnut only when necessary (i.e. the graph section is active and we are on either greenhouse or final section)
* stored the formindex in the wizard store and changed getActiveForm to return the active form without requiring the index as argument
* created a RESETCONFIG to reinitialize the store values (before if you logged out and logged in again, you would find the previous values already selected) and call it while starting the config wizard
* changed the doughnut, so that no graph is showed if the greenhouse type/size is not defined -- instead it shows "No Greenhouse Type Selected" both in the config and in the dashboard
* removed the Greenhouse Doughnut Calculating from the dashboard for two reasons: 1) it makes the code simpler; 2) we already have the initial value and we can show them without calculating anything

@gschoberth : it would be great if you could review this before tomorrow, so that I can include it before we update dist on the main simoc repo