### PR TITLE
#8: add a simple confirm() popup.

### DIFF
--- a/src/components/dashboard/MainMenu.vue
+++ b/src/components/dashboard/MainMenu.vue
@@ -74,6 +74,9 @@ export default {
         },
         // Logout button route
         logout: async function(){
+            if (!confirm('Stop the current simulation and log out?')) {
+                return;
+            }
             const localHost = "http://localhost:8000"
             const path = "/logout"
             const logoutRoute = this.getUseLocalHost ? localHost + path : path
@@ -88,6 +91,9 @@ export default {
 
         // New Simulation button
         toConfiguration: async function(){
+            if (!confirm('Stop the current simulation and configure a new one?')) {
+                return;
+            }
             this.stopSimulation()
             this.$router.push("configuration")
         }


### PR DESCRIPTION
First implementation of the confirmation popups.

This simply adds confirmation popups to the Log Out and New Simulation buttons of the dashboard menu.  This implementation uses confirm() which is ugly and blocking; in the future we should find a better popup and use it for other menus too.
