### PR TITLE
 #2: reset values and empty data buffers when a new game starts. 

### DIFF
--- a/src/store/modules/dashboard.js
+++ b/src/store/modules/dashboard.js
@@ -32,8 +32,8 @@ export default{
         totalProduction:{},
         totalConsumption:{},
         storageRatio:{},
-        maxStepBuffer: 1,      // the number of steps in the buffer
-        currentStepBuffer: 1,  // the step the simulation is displaying
+        maxStepBuffer: 0,      // the number of steps in the buffer
+        currentStepBuffer: 0,  // the step the simulation is displaying
         stepInterval: 1000,    // the time between the steps, in milliseconds
         terminated: false,     // true if we retrieved all steps from the server
         timerID:undefined,

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -19,12 +19,13 @@ export default {
         if (this.getGetStepsTimerID) {
             window.clearTimeout(this.getGetStepsTimerID)
         }
-        console.log('Starting simulation', this.getGameID)
+        // reset more variables
+        // the buffer current should be 0 so its value is updated when step 1 is received
         this.SETTIMERID(undefined)          // Set the timerID to undefined
         this.SETGETSTEPSTIMERID(undefined)  // Set the getStepsTimerID to undefined
-        this.SETBUFFERCURRENT(1)            // Reset the current buffer value
-        this.SETBUFFERMAX(1)                // Reset the max buffer value
-        this.SETMINSTEPNUMBER(1)            // Reset the starting step
+        this.SETBUFFERCURRENT(0)            // Reset the current buffer value
+        this.SETBUFFERMAX(0)                // Reset the max buffer value
+        this.SETMINSTEPNUMBER(0)            // Reset the starting step
         this.SETTERMINATED(false)           // Reset the termination conditions have been met flag
 
         // init a new game, set game id, reset all data buffers
@@ -109,7 +110,10 @@ export default {
         // this method pauses the current simulation if the current step
         // is at or beyond the amount of steps that are currently buffered
         getCurrentStepBuffer: function() {
-            if (this.getCurrentStepBuffer >= this.getMaxStepBuffer) {
+            // check that we have values in the buffer to avoid pausing
+            // the timer when current/max are set to 0 at the beginning
+            if ((this.getMaxStepBuffer > 1) &&
+                (this.getCurrentStepBuffer >= this.getMaxStepBuffer)) {
                 this.PAUSETIMER()
             }
         },


### PR DESCRIPTION
This fixes #2.
I created an INITGAME mutation that (re)initializes the parameters and all the data buffers.
I also set the initial values to 0 so that the graphs are updated when the first step is received and the current step is updated to 1.