### PR TITLE
Add keyboard shortcuts to the dashboard.

### DIFF
--- a/src/components/dashboard/SpeedControls.vue
+++ b/src/components/dashboard/SpeedControls.vue
@@ -27,6 +27,24 @@ export default {
         this.speedIndex = 2
         this.changeSpeed(0)
     },
+    mounted() {
+        // Handle keyboard shortcuts for +/-
+        // The rest of the shortcuts are in DashboardView
+        this.keyListener = function(e) {
+            if (e.key === '+') {
+                this.changeSpeed(+1)
+                e.preventDefault()
+            }
+            else if (e.key === '-') {
+                this.changeSpeed(-1)
+                e.preventDefault()
+            }
+        }
+        window.addEventListener('keydown', this.keyListener.bind(this))
+    },
+    beforeDestroy: function() {
+        window.removeEventListener('keydown', this.keyListener);
+    },
     methods:{
         ...mapMutations('dashboard', ['SETSTEPINTERVAL']),
         changeSpeed: function(offset) {


### PR DESCRIPTION
This PR adds keyboard shortcuts to the dashboard:
```
//   spacebar: play/pause
//   left/right arrows: ±1 step
//   down/up arrows: ±10 steps
//   pagedown/pageup arrows: ±24 steps
//   home/end: first/last step
//   +/-: increase/decrease speed*
```
Most of the shortcuts handling is done in `DashboardView.vue` since the logic is trivial and this allows us to have most shortcuts in one place and set a single listener.  However the shortcut handling for `+/-` is implemented in the `SpeedControls.vue` because there is some non trivial logical that I didn't want to duplicate.