### PR TITLE
Use async import() to load simdata lazily and enforce webpack splitting.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -374,12 +374,20 @@
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
-      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-syntax-json-strings": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "vuex": "^3.0.1"
   },
   "devDependencies": {
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@vue/cli-plugin-babel": "^3.9.0",
     "@vue/cli-plugin-eslint": "^3.9.0",
     "@vue/cli-service": "^3.9.0",

--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -161,13 +161,19 @@ export default {
             }
         },
 
-        importPresetData:function(preset) {
+        importPresetData:async function(preset) {
             // import cached simulation data for the preset
             try {
                 console.log('* Loading cached simdata...')
                 const fname = preset.simdata_file.split('.')[0]
-                const data = require('../assets/simdata/' + fname + '.json')
-                return data
+                // Two important things happen here:
+                // 1) the import should happen asynchronously
+                // 2) webpack shouldn't bundle the simdata with the rest
+                // Using this form of await import(stringliteral + var + stringliteral)
+                // should ensure that webpack/babel recognize that these modules are
+                // imported dynamically and lazily and that they shoultn't be bundled
+                const simdata = await import('../assets/simdata/' + fname + '.json')
+                return simdata.default  // get the actual data out of the module object
             } catch(error) {
                 console.log('* Loading cached simdata failed, falling back on regular request')
                 console.error(error)
@@ -200,7 +206,7 @@ export default {
             const presets = this.getPresets
             const preset_name = this.$refs.presets.$refs.preset_dropdown.value
             if (preset_name in presets) {
-                const simdata = this.importPresetData(presets[preset_name])
+                const simdata = await this.importPresetData(presets[preset_name])
                 if (simdata) {
                     try {
                         this.SETCONFIGURATION(simdata.configuration)


### PR DESCRIPTION
This is a follow-up to #71 and addresses an issue reported in #70.
Apparently on the dev server, webpack doesn't create a single bundle, so the json simdata were loaded lazily on the dev server but not in production, where they were bundled together with the rest, creating a multi-MB bundle.

Currently (i.e. before this PR), by looking at the inspector we can see there is a 7.35MB js bundle followed by another 1.17MB bundle:
![20210627--01](https://user-images.githubusercontent.com/25624924/123532105-9e468a80-d70a-11eb-83db-36ccebf69512.png)

This PR fixes this issue by using webpack code-splitting, in combination with the ES6 async `import()` function to lazily load the presets.

As far as I understand, in the current code, the `require()` function is used to load the simdata dynamically and to parse the JSON, but webpack (maybe because of babel?) can't recognize that the modules are to be loaded lazily, and bundles them with the rest.  Using the `import()` function asynchronously allows webpack (thanks to babel?) to know that these modules should be imported lazily and that they should be bundled separately.

Some references:
https://github.com/webpack/webpack/issues/5703
https://vuejsdevelopers.com/2017/07/03/vue-js-code-splitting-webpack/
https://vuedose.tips/dynamic-imports-in-vue-js-for-better-performance/
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import