### PR TITLE
Fix and improve greenhouse plants validation.

### DIFF
--- a/src/store/modules/wizard.js
+++ b/src/store/modules/wizard.js
@@ -325,6 +325,7 @@ export default {
         // Updates the plant at the index with the new values
         UPDATEPLANTSPECIES: (state, value) => {
             const {index, plant} = value
+            plant.amount = parseInt(plant.amount, 10)
             state.configuration.plantSpecies[index] = plant
         },
         // Removes the plant at the index


### PR DESCRIPTION
This PR fixes and improves the plant validation, and the issue reported in #83.
In addition it will now display the first invalid error instead of the last.
I also updated the code and the comments to make them more readable.

There are still some corner cases, e.g. if the user sets more that one value above the limit, then the error will just tell the user not to go above the limit of the greenhouse for that specific plant, but once that's fixed it will show another error that says that even if the individual fields are ok, the total is above the limit (when possible it tries to calculate the correct limit for each individual field).

Fixes #83.