### PR TITLE
Disable artifact creation and repository dispatch in GHA.

### DIFF
--- a/.github/workflows/build-frontend-prod.yml
+++ b/.github/workflows/build-frontend-prod.yml
@@ -44,17 +44,26 @@ jobs:
           npm run build --if-present
           npm test --if-present
           npm run lint -- --no-fix
-      - name: Create Frontend Artifacts
-        run: tar -cvf frontend_dist.tar dist/
-      - name: Save Frontend Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist-archive
-          path: frontend_dist.tar
-      - name: Backend Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.ACCESS_TOKEN }}
-          repository: overthesun/simoc
-          event-type: frontend-update-prod
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+      # To avoid hitting the artifact quota,
+      # disable the next two steps for now.
+      # The artifact doesn't seem to be used anyway.
+#     - name: Create Frontend Artifacts
+#       run: tar -cvf frontend_dist.tar dist/
+#     - name: Save Frontend Artifacts
+#       uses: actions/upload-artifact@v2
+#       with:
+#         name: dist-archive
+#         path: frontend_dist.tar
+      # This step can be used to notify the backend
+      # that the frontend changed.  The backend can
+      # then listen to a repository_dispatch event
+      # and automatically build and deploy the
+      # changes.  Backend deployment is triggered
+      # manually now, so this step is disabled too.
+#     - name: Backend Repository Dispatch
+#       uses: peter-evans/repository-dispatch@v1
+#       with:
+#         token: ${{ secrets.ACCESS_TOKEN }}
+#         repository: overthesun/simoc
+#         event-type: frontend-update-prod
+#         client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
This PR does two things:
1. it disable artifacts creation, since they don't seem to be used anyway (if they are we will realize that soon enough) and take up space, making us hit the artifact quota.
2. it disable the repository dispatch step.

As far as I understand, the initial setup was configured so that whenever something was pushed/merged on the frontend repo, it would build the frontend, create an artifact, and use the repository dispatch action to notify the backend repo of the update.  This would trigger an action on the backend repo that caused it to build and deploy the backend automatically on NGS/Beta.

I've already disabled automatic deployment of the backend for both push/merge and repository dispatch events (in https://github.com/overthesun/simoc/commit/e3cd0b3b79f7718f0389e4e1bef0de18a746478f), so even if the frontend sends a repository dispatch event to the backend, the event is ignored.  Currently deployment on the backend is only triggered manually.

Regarding the frontend artifact creation, I was thinking whether it was used by the backend after receiving the repository dispatch event, but it seems that it just clones the frontend repo and rebuilds the frontend again, without using the artifact.