### PR TITLE
Add modes support to panels. (#123)

### DIFF
--- a/src/components/dashboard/DashboardMenu.vue
+++ b/src/components/dashboard/DashboardMenu.vue
@@ -35,7 +35,8 @@ export default {
     },
     computed: {
         ...mapGetters('wizard', ['getConfiguration']),
-        ...mapGetters('dashboard', ['getIsTimerRunning', 'getActivePanels', 'getSimulationData']),
+        ...mapGetters('dashboard', ['getIsTimerRunning', 'getActivePanels', 'getSimulationData',
+                                    'getCurrentMode']),
         ...mapGetters(['getGameID']),
     },
     mounted() {
@@ -84,7 +85,7 @@ export default {
         // Reset Panels Layout button
         resetPanelsLayout() {
             localStorage.removeItem('panels-layout')
-            this.SETDEFAULTPANELS()
+            this.SETDEFAULTPANELS(this.getCurrentMode)
         },
         // Logout button route
         async logout() {

--- a/src/components/dashboard/Main.vue
+++ b/src/components/dashboard/Main.vue
@@ -70,12 +70,14 @@ export default {
     },
     computed: {
         ...mapGetters('wizard', ['getConfiguration']),
-        ...mapGetters('dashboard', ['getActivePanels']),
+        ...mapGetters('dashboard', ['getActivePanels', 'getCurrentMode']),
         sortedPanels() {
             // return a sorted array of [[title, name], [..., ...], ...]
             const sorted = []
             Object.entries(this.panels).forEach(([panelName, panel]) => {
-                sorted.push([panel.panelTitle, panelName])
+                if (panel.modes.includes(this.getCurrentMode)) {
+                    sorted.push([panel.panelTitle, panelName])
+                }
             })
             return sorted.sort()
         },
@@ -91,7 +93,7 @@ export default {
         if (savedPanels) {
             this.SETACTIVEPANELS(JSON.parse(savedPanels))
         } else {
-            this.SETDEFAULTPANELS()
+            this.SETDEFAULTPANELS(this.getCurrentMode)
         }
     },
     methods: {

--- a/src/components/entry/Menu.vue
+++ b/src/components/entry/Menu.vue
@@ -47,7 +47,8 @@ export default {
         window.removeEventListener('keydown', this.keyListener)
     },
     methods: {
-        ...mapMutations('dashboard', ['SETSIMULATIONDATA', 'SETLOADFROMSIMDATA', 'SETBUFFERMAX']),
+        ...mapMutations('dashboard', ['SETSIMULATIONDATA', 'SETLOADFROMSIMDATA', 'SETBUFFERMAX',
+                                      'SETCURRENTMODE']),
         ...mapMutations('wizard', ['SETACTIVECONFIGTYPE']),
         ...mapActions('wizard', ['SETCONFIGURATION']),
         ...mapActions('modal', ['alert', 'showSurvey']),
@@ -55,7 +56,6 @@ export default {
         toConfiguration() {
             // menuconfig is currently skipped, we default on Custom config
             // this.$router.push('menuconfig')
-
             this.SETACTIVECONFIGTYPE('Custom')
             this.$router.push('configuration')
         },
@@ -87,6 +87,7 @@ export default {
                 this.alert('An error occurred while reading the file.')
                 return
             }
+            this.SETCURRENTMODE('sim')
             this.SETLOADFROMSIMDATA(true)
             this.$router.push('dashboard')
         },

--- a/src/components/panels/AtmosphericMonitors.vue
+++ b/src/components/panels/AtmosphericMonitors.vue
@@ -45,6 +45,7 @@ import {Gauge} from '../graphs'
 
 export default {
     panelTitle: 'Atmospheric Monitors',
+    modes: ['sim'],
     components: {
         Gauge,
     },

--- a/src/components/panels/ConsumptionBreakdown.vue
+++ b/src/components/panels/ConsumptionBreakdown.vue
@@ -25,6 +25,7 @@ import {StringFormatter} from '../../javascript/utils'
 
 export default {
     panelTitle: 'Consumption Breakdown',
+    modes: ['sim'],
     data() {
         return {
             selected_currency: null,

--- a/src/components/panels/GreenhouseConfig.vue
+++ b/src/components/panels/GreenhouseConfig.vue
@@ -10,6 +10,7 @@ import {GreenhouseDoughnut} from '../graphs'
 
 export default {
     panelTitle: 'Greenhouse Configuration',
+    modes: ['sim'],
     components: {
         GreenhouseDoughnut,
     },

--- a/src/components/panels/InhabitantsStatus.vue
+++ b/src/components/panels/InhabitantsStatus.vue
@@ -33,6 +33,7 @@ import {StringFormatter} from '../../javascript/utils'
 
 export default {
     panelTitle: 'Inhabitants Status',
+    modes: ['sim'],
     data() {
         return {
             // shades of red to warn the user when values pass the threshold

--- a/src/components/panels/MissionInfo.vue
+++ b/src/components/panels/MissionInfo.vue
@@ -70,6 +70,7 @@ import {StringFormatter} from '../../javascript/utils'
 
 export default {
     panelTitle: 'Mission Information',
+    modes: ['sim'],
     data() {
         return {
             info_section: 'mission-status',

--- a/src/components/panels/PlantGrowth.vue
+++ b/src/components/panels/PlantGrowth.vue
@@ -22,6 +22,7 @@ import {StringFormatter} from '../../javascript/utils'
 
 export default {
     panelTitle: 'Greenhouse Plant Growth',
+    modes: ['sim'],
     computed: {
         ...mapGetters('wizard', ['getConfiguration']),
         ...mapGetters('dashboard', ['getAgentGrowth', 'getCurrentStepBuffer', 'getAgentType']),

--- a/src/components/panels/ProductionConsumption.vue
+++ b/src/components/panels/ProductionConsumption.vue
@@ -20,6 +20,7 @@ import {VersusGraph} from '../graphs'
 
 export default {
     panelTitle: 'Production / Consumption',
+    modes: ['sim'],
     components: {
         VersusGraph,
     },

--- a/src/components/panels/StorageLevels.vue
+++ b/src/components/panels/StorageLevels.vue
@@ -24,6 +24,7 @@ import {StringFormatter} from '../../javascript/utils'
 
 export default {
     panelTitle: 'Storage Levels',
+    modes: ['sim'],
     computed: {
         ...mapGetters('wizard', ['getConfiguration']),
         ...mapGetters('dashboard', ['getCurrentStepBuffer', 'getStorageCapacities']),

--- a/src/components/panels/StorageRatios.vue
+++ b/src/components/panels/StorageRatios.vue
@@ -19,6 +19,7 @@ import {LevelsGraph} from '../graphs'
 
 export default {
     panelTitle: 'Storage Ratios',
+    modes: ['sim'],
     components: {
         LevelsGraph,
     },

--- a/src/components/panels/ThreeDPanel.vue
+++ b/src/components/panels/ThreeDPanel.vue
@@ -8,6 +8,7 @@ import World from '../../threejs/World'
 
 export default {
     panelTitle: 'Habitat View',
+    modes: ['sim'],
     components: {
         World: World,
     },

--- a/src/store/modules/dashboard.js
+++ b/src/store/modules/dashboard.js
@@ -54,6 +54,7 @@ export default {
         loadFromSimData: false,  // if true, load from imported sim data, not from the server
         gameConfig: {},  // the full game_config returned by /new_game
         activePanels: [],
+        currentMode: '',
     },
     getters: {
         getMenuActive: state => state.menuActive,
@@ -83,6 +84,7 @@ export default {
         getIsTimerRunning: state => state.isTimerRunning,
         getGameConfig: state => state.gameConfig,
         getActivePanels: state => state.activePanels,
+        getCurrentMode: state => state.currentMode,
         // return a json obj that contains all the simulation data
         getSimulationData(state) {
             return {
@@ -286,11 +288,17 @@ export default {
         SETACTIVEPANELS(state, panels) {
             state.activePanels = panels
         },
-        SETDEFAULTPANELS(state) {
-            state.activePanels = [
-                'MissionInfo', 'ProductionConsumption:enrg_kwh', 'StorageLevels',
-                'InhabitantsStatus', 'ProductionConsumption:atmo_co2', 'AtmosphericMonitors',
-            ]
+        SETDEFAULTPANELS(state, mode) {
+            state.activePanels = {
+                sim: [
+                    'MissionInfo', 'ProductionConsumption:enrg_kwh', 'StorageLevels',
+                    'InhabitantsStatus', 'ProductionConsumption:atmo_co2', 'AtmosphericMonitors',
+                ],
+            }[mode]
+        },
+        // Set current mode
+        SETCURRENTMODE(state, value) {
+            state.currentMode = value
         },
         INITGAME(state, value) {
             // set a new game_id and reset all other values

--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -150,7 +150,7 @@ export default {
     methods: {
         ...mapMutations('wizard', ['RESETCONFIG', 'SETACTIVEFORMINDEX']),
         ...mapMutations('dashboard', ['SETGAMECONFIG', 'SETSIMULATIONDATA',
-                                      'SETLOADFROMSIMDATA', 'SETBUFFERMAX']),
+                                      'SETLOADFROMSIMDATA', 'SETBUFFERMAX', 'SETCURRENTMODE']),
         ...mapMutations(['SETGAMEID']),
         ...mapActions('wizard', ['SETCONFIGURATION']),
         ...mapActions('modal', ['alert']),
@@ -241,6 +241,7 @@ export default {
                         this.SETCONFIGURATION(simdata.configuration)
                         this.SETSIMULATIONDATA(simdata)
                         this.SETBUFFERMAX(simdata.steps)
+                        this.SETCURRENTMODE('sim')
                         this.SETLOADFROMSIMDATA(true)
                         this.$router.push('dashboard')
                         return  // nothing else to do if this worked
@@ -270,6 +271,7 @@ export default {
                 // store the game ID and full game_config from the response
                 this.SETGAMEID(response.data.game_id)
                 this.SETGAMECONFIG(response.data.game_config)
+                this.SETCURRENTMODE('sim')
                 this.SETLOADFROMSIMDATA(false)
                 // If all is well then move the user to the dashboard screen
                 this.$router.push('dashboard')


### PR DESCRIPTION
This PR adds modes support to panels.  It's now possible to set the current mode, and only the panels that support that mode will be available in the dashboard.

Resolves #120.