### PR TITLE
Fix save panel layout bug incompatible panels Issue#129.

### DIFF
--- a/src/components/dashboard/DashboardMenu.vue
+++ b/src/components/dashboard/DashboardMenu.vue
@@ -80,11 +80,11 @@ export default {
         // Save Panels Layout button
         savePanelsLayout() {
             const panelsLayout = JSON.stringify(this.getActivePanels)
-            localStorage.setItem(`${this.getCurrentMode}-panels-layout`, panelsLayout)
+            localStorage.setItem(`panels-layout-${this.getCurrentMode}`, panelsLayout)
         },
         // Reset Panels Layout button
         resetPanelsLayout() {
-            localStorage.removeItem(`${this.getCurrentMode}-panels-layout`)
+            localStorage.removeItem(`panels-layout-${this.getCurrentMode}`)
             this.SETDEFAULTPANELS(this.getCurrentMode)
         },
         // Logout button route

--- a/src/components/dashboard/Main.vue
+++ b/src/components/dashboard/Main.vue
@@ -89,7 +89,7 @@ export default {
     },
     beforeMount() {
         // load saved panels from local storage or use default layout
-        const savedPanels = localStorage.getItem(`${this.getCurrentMode}-panels-layout`)
+        const savedPanels = localStorage.getItem(`panels-layout-${this.getCurrentMode}`)
         if (savedPanels) {
             this.SETACTIVEPANELS(JSON.parse(savedPanels))
         } else {


### PR DESCRIPTION
The simplest solution to this issue was creating new localStorage variables. 

When the user presses the Save Panels Layout button in the DashboardMenu, depending on which Dashboard the button is pressed in updates one of two localStorage variables: live-panels-layout or sim-panels-layout.