### PR TITLE
Fix Google Analytics on Beta.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,8 +20,8 @@ createApp(App)
         .use(VueGtag, {
             // enable Gtag/Analytics tracking
             // remember to use the right code for each branch
-            config: {id: 'UA-29092818-6'},
-            enabled: process.env.NODE_ENV === 'production',
+            property: {id: 'UA-29092818-7'},
+            isEnabled: process.env.NODE_ENV === 'production',
         }, router)
         .component('FaIcon', FontAwesomeIcon)
         .component('FaLayers', FontAwesomeLayers)


### PR DESCRIPTION
This should fix #136.  Apparently there were some API changes in the new version and the new version failed silently when invoked with the old API.