### PR TITLE
Restore GitHub Action check on push.

### DIFF
--- a/.github/workflows/build-frontend-prod.yml
+++ b/.github/workflows/build-frontend-prod.yml
@@ -1,6 +1,9 @@
 name: SIMOC Frontend Check
 
 on:
+  push:
+    branches:
+    - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
This should trigger the check in two cases:
1. when a PR is merged on `master`
2. when a commit is pushed directly on `master`

In general we shouldn't push directly on master and all merged changes should go through a PR, but it's good to have it just in case.