### PR TITLE
Remove unnecessary branch filter from GHA.

### DIFF
--- a/.github/workflows/build-frontend-prod.yml
+++ b/.github/workflows/build-frontend-prod.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - "**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This filter shouldn't be necessary.
The `pull_request` trigger is only activated if the PR comes from the same repo.