### PR TITLE
Decouple the docker container from the backend.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ CMD ["run.sh"]
 #
 # Run the container using:
 #   docker run --rm --network simoc_simoc-net -p 8080:8080 -v `pwd`:/frontend -it frontend-dev
+#
+# Omit the --network arg if you don't need to connect to the backend.
 
 
 # To automatically run the frontend the dockerfile can be changed to:

--- a/simoc-web.py
+++ b/simoc-web.py
@@ -28,8 +28,13 @@ def run(args):
 
 def docker_run(*args):
     """Run an arbitrary docker-compose command."""
-    return run(['docker', 'run', '--rm', '--network', 'simoc_simoc-net',
-                '-p', '8080:8080', '-v', f'{SIMOC_WEB_DIR}:/frontend', *args])
+    # detect and connect to the network if it's available
+    net_name = 'simoc_simoc-net'
+    cp = subprocess.run(['docker', 'network', 'inspect', net_name],
+                        capture_output=True)
+    net_args = ['--network', net_name] if cp.returncode == 0 else []
+    return run(['docker', 'run', '--rm', *net_args, '-p', '8080:8080',
+                '-v', f'{SIMOC_WEB_DIR}:/frontend', *args])
 
 
 @cmd


### PR DESCRIPTION
Fixes #168 by detecting and connecting to the `simoc-net` docker network only if it's available.  This allows the frontent to run even if the backend (and the `simoc-net` network) are not available (e.g. while running simoc-sam or during installation).