### PR TITLE
Remove branch version from GitHub workflow.

### DIFF
--- a/.github/workflows/build-frontend-prod.yml
+++ b/.github/workflows/build-frontend-prod.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-        with:
-          ref: master
       - name: Setup Node Environment
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This PR fixes a bug exposed by #196.  Before this change this workflow always ran on `master`, even for pull requests.