### PR TITLE
Increase `dependabot` open PR limit to 10.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,4 @@ updates:
       interval: "daily"
     assignees:
       - "ezio-melotti"
-    open-pull-requests-limit:
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This PR increases `dependabot`'s open PR limit to 10 (the default is 5).