### PR TITLE
Split `npm` commands into separate steps.

### DIFF
--- a/.github/workflows/build-frontend-prod.yml
+++ b/.github/workflows/build-frontend-prod.yml
@@ -36,13 +36,16 @@ jobs:
           mkdir models
           cd models
           wget -r -nH --cut-dirs=2 --no-parent --accept="*.glb" -erobots=off -q --show-progress https://simoc.space/download/models/
-      - name: npm install, build, test, and lint
+      - name: npm install
         run: |
           npm install -g npm@latest
           npm install
-          npm run build --if-present
-          npm test --if-present
-          npm run lint -- --no-fix
+      - name: build
+        run: npm run build --if-present
+      - name: test
+        run: npm run test --if-present
+      - name: lint
+        run: npm run lint -- --no-fix
       # To avoid hitting the artifact quota,
       # disable the next two steps for now.
       # The artifact doesn't seem to be used anyway.


### PR DESCRIPTION
This PR splits the `npm` commands (`install`, `build`, `test`, `lint`) into separate steps in the CI workflow.  This will make it easier to see which command failed.