### PR TITLE
Fix `vite` local proxy settings

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,18 @@ import eslint from 'vite-plugin-eslint'
 import postcssNesting from 'postcss-nesting';
 import path from 'path';
 
+
+// This regex lists the paths that should NOT go to nginx, including
+//   $: i.e. empty location, or simply localhost:8080/
+//   @: some vite-related paths starts with @
+//   src: the frontend files in src/
+//   node_modules: self explanatory
+//   favicon.ico: self explanatory
+//   *: the rest are the routers defined in router.js
+// These paths should go to vite, everything else will go to nginx.
+const nginx_paths = ('^/(?!$|@|src|node_modules|favicon\.ico|' +
+                     'entry|menu|menuconfig|ace|configuration|dashboard)')
+
 // https://vitejs.dev/config/
 export default defineConfig({
     assetsInclude: ['**/*.glb'],
@@ -14,12 +26,12 @@ export default defineConfig({
     },
     server: {
         proxy: {
-            '/*': {
+            [nginx_paths]: {
                 target: 'http://nginx:8000',
                 changeOrigin: true,
                 secure: false,
-            }
-        }
+            },
+        },
     },
     build: {
         assetsDir: 'static',


### PR DESCRIPTION
In the `vue.config.js` we used to proxy `/*`:
https://github.com/overthesun/simoc-web/blob/dd5fc3fd32af503182db29ffe10d45313e596ec9/vue.config.js#L10-L14
After switching to `vite`, we are now using `/`:
https://github.com/overthesun/simoc-web/blob/efc2e5a552697da2469e9c6623d0535fe82c2717/vite.config.js#L16-L21

This seems to break `npm run dev` locally.

My understanding is that by using `/`, when we open `localhost:8080` it will request `/`, match the proxy setting, and redirect to `nginx:8000`, thus requesting the frontend included in backend.  This will only work if the backend is running and has a working `simoc_server/dist`, but won't include changes made to frontend.

By using `/*`, the request to `/` won't be proxied and the browser will access the dev frontend served by `npm run dev`.  Then all the other requests will be forwarded to the backend (e.g. to retrieve step data).