### PR TITLE
fix precision in VersusGraph

### DIFF
--- a/src/components/graphs/VersusGraph.vue
+++ b/src/components/graphs/VersusGraph.vue
@@ -92,7 +92,10 @@ export default {
                         yAxes: [{
                             ticks: {
                                 beginAtZero: true,
-                                callback: (value, index, values) => `${value.toPrecision(2)} ${this.unit}`,
+                                callback: (value, index, values) => {
+                                    const val = value > 0 ? value : value.toPrecision(2)
+                                    return `${val} ${this.unit}`
+                                },
                             },
                         }],
                         xAxes: [{


### PR DESCRIPTION
When ytick value < 0, use `Number.toPrecision(2)` to minimize space.