### PR TITLE
Fix percentages in the scrubber bars.

### DIFF
--- a/src/components/dashboard/Timeline.vue
+++ b/src/components/dashboard/Timeline.vue
@@ -92,9 +92,10 @@ export default {
             this.currentStep = this.currentStepBuffer
             // Before we receive steps from the server, the currentStep (and first step) is 0.
             // Once we receive the first step, the first step becomes 1, and step 0 is removed.
-            // Because of this we need to subtract 1 to all the values.
-            this.currentPercentage = ((this.currentStepBuffer-1) / (this.getTotalMissionHours-1)) * 100
-            this.bufferPercentage = ((this.maxStepBuffer-1) / (this.getTotalMissionHours-1)) * 100
+            // Because of this we need to subtract 1 from all the values.
+            const totalMissionHours = this.getTotalMissionHours - 1
+            this.currentPercentage = ((this.currentStepBuffer - 1) / totalMissionHours) * 100
+            this.bufferPercentage = ((this.maxStepBuffer - 1) / totalMissionHours) * 100
         },
     },
 }


### PR DESCRIPTION
This is a follow-up of #245 and fixes the problem with the scrubber discussed there.

What happened was an off-by-one error that caused the bar to *always* be misaligned with the scrubber thumb (the green circle).  The longer the simulation was, the smaller was the error, so in most cases the error was hidden behind the thumb, and only became apparent for shorter sims (e.g. 24h) where each step took a bigger portion of the bar.

IOW for a 24h sim:
* the bar would show 24 steps (from 1 to 24, with 1 all the way to the left and 24 all the way to the right)
* at step 1 the thumb would sit all the way to the left (i.e. at 0%)
* before this fix, the green bar in the background would be at 1/24 (i.e. 4.16%), enough to be larger than the thumb and show up ahead of the thumb (like Ryan reported):
   <img width="1034" alt="Screen Shot 2022-11-06 at 8 19 21 AM" src="https://user-images.githubusercontent.com/58452495/200182229-fdc2e6d3-761b-4d82-a357-5f5c7317f0d2.png">
* after the fix, the green bar would be at 0/23 (i.e. 0%), and would be correctly aligned with thumb