### PR TITLE
Fix broken menu bug.

### DIFF
--- a/src/components/base/BaseDashboard.vue
+++ b/src/components/base/BaseDashboard.vue
@@ -38,14 +38,14 @@ export default {
         Dashboard,
     },
     beforeRouteLeave(to, from, next) {
-        // Ensure the menu on the Dashboard is closed before showing modal.
-        this.menuActive = false
-
         // Triggered when leaving the dashboard to go to another page.
         // This might happen when the user starts a new sim or logs off,
         // but also when clicking on the browser back button.
         // Cases where the user closes the tab or refreshes are handled
         // in DashboardView.
+
+        // Ensure the menu on the Dashboard is closed before showing any modal.
+        this.menuActive = false
         if (this.leaveWithoutConfirmation) {
             this.leaveWithoutConfirmation = false  // reset value
             next()  // proceed without asking questions

--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -172,16 +172,13 @@ export default {
             this.idle.start()
         }
         this.resetConfigDefault()
+        this.menuActive = false
         this.activeForm = this.getActiveForm
     },
     beforeUnmount() {
         if (this.currentMode === 'kiosk') {
             this.idle.stop()
         }
-
-        // Menu will malfunction if user hits back on browser.
-        // Setting this false ensures menu is inactive on unmount.
-        this.menuActive = false
     },
     methods: {
         ...mapMutations(['SETGAMEID']),

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -80,6 +80,7 @@ export default {
         this.timerID = null
         this.getStepsTimerID = null
         this.currentStepBuffer = 0
+        this.menuActive = false
         this.setMinStepNumber(0)  // Currently unused
         this.setStopped(false)
 


### PR DESCRIPTION
This PR fixes bug found in #204. In ConfigurationView, menuActive is now set to false on component beforeUnmount. This ensures anytime the user hits back the menu will properly close. 