### PR TITLE
add sam greenhouse size to config graph

### DIFF
--- a/src/components/graphs/GreenhouseConfig.vue
+++ b/src/components/graphs/GreenhouseConfig.vue
@@ -26,6 +26,7 @@ export default {
                 greenhouse_small: 490,
                 greenhouse_medium: 2454,
                 greenhouse_large: 5610,
+                greenhouse_sam: 272,
             },
             // colors used for the plants in the graphs
             colors: ['#ff0000', '#ee0000', '#dd0000', '#cc0000', '#bb0000', '#aa0000',


### PR DESCRIPTION
Just a tiny thing, I noticed the chart didn't populate if you select the SAM greenhouse.