### PR TITLE
Log "Launch Simulation" errors on Google Analytics.

### DIFF
--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -191,6 +191,8 @@ export default {
         },
 
         handleAxiosError(error) {
+            const errmsg = error.response.data.message || error.message
+            this.$gtag.exception({description: `Launch simulation: ${errmsg}`})
             console.error(error)
             if (error.response && error.response.status === 401) {
                 this.alert('Please log in again to continue.')


### PR DESCRIPTION
This PR adds a custom Google Analytics event to log errors thrown while launching a simulation from the config wizard.