### PR TITLE
Show all steps in fullscreen production/consumption panel.

### DIFF
--- a/src/components/dashboard/Main.vue
+++ b/src/components/dashboard/Main.vue
@@ -44,8 +44,8 @@ The layout of each panel is defined in BasePanel.vue to avoid duplication.
                 </div>
             </template>
             <template #panel-content>
-                <component :is="panelName" :canvas-number="index"
-                           :panel-index="index" :panel-section="panelSection"
+                <component :is="panelName" :canvas-number="index" :panel-index="index"
+                           :panel-section="panelSection" :fullscreen="isFullscreen"
                            @panel-section-changed="updatePanelSection" />
             </template>
         </BasePanel>

--- a/src/components/panels/ProductionConsumption.vue
+++ b/src/components/panels/ProductionConsumption.vue
@@ -9,7 +9,9 @@
             <option :selected="currency === 'kwh'" value="kwh">Energy</option>
         </select>
         <div>
-            <VersusGraph :id="'canvas-pc-' + canvasNumber" :plotted-value="currency" :unit="units[currency]" />
+            <VersusGraph :id="'canvas-pc-' + canvasNumber" :plotted-value="currency"
+                         :unit="units[currency]" :fullscreen="fullscreen"
+                         :nsteps="fullscreen?getTotalMissionHours:24" />
         </div>
     </div>
 </template>
@@ -17,6 +19,7 @@
 <script>
 import {storeToRefs} from 'pinia'
 import {useDashboardStore} from '../../store/modules/DashboardStore'
+import {useWizardStore} from '../../store/modules/WizardStore'
 import {VersusGraph} from '../graphs'
 
 export default {
@@ -31,12 +34,15 @@ export default {
         // determine the panel index and the selected graph
         panelIndex: {type: Number, required: true},
         panelSection: {type: String, default: null},
+        fullscreen: {type: Boolean, default: false},
     },
     emits: ['panel-section-changed'],
     setup() {
         const dashboard = useDashboardStore()
+        const wizard = useWizardStore()
         const {activePanels} = storeToRefs(dashboard)
-        return {activePanels}
+        const {getTotalMissionHours} = storeToRefs(wizard)
+        return {activePanels, getTotalMissionHours}
     },
     data() {
         return {


### PR DESCRIPTION
This PR is a follow-up of #103 and updates the Production/Consumption panel and the versus graph to show all steps when the panel is fullscreen.