### PR TITLE
Add simLocation to DashboardStore

### DIFF
--- a/src/store/modules/DashboardStore.js
+++ b/src/store/modules/DashboardStore.js
@@ -58,6 +58,7 @@ export const useDashboardStore = defineStore('DashboardStore', {
     state: () => ({
         // Game Management
         currentMode: '',
+        simLocation: 'mars',
         activePanels: [],
         loadFromSimData: false,  // if true, load from imported sim data, not from the server
         terminated: false,       // true if we stopped or retrieved all steps from the server


### PR DESCRIPTION
@ezio-melotti What do you think about calling the location var `simLocation`, and leaving it a string value for "mars" or "b2"? I can add it to the other classes for Ryan to access if needed, I'll touch base with him.

When B2 option is selected, I'll update this value to "b2".