### PR TITLE
increase solar in 4hg preset

### DIFF
--- a/src/store/modules/WizardStore.js
+++ b/src/store/modules/WizardStore.js
@@ -110,7 +110,7 @@ export const useWizardStore = defineStore('WizardStore', {
                 food: {type: 'food_storage', amount: 1200, units: 'kg'},
                 crewQuarters: {type: 'crew_habitat_medium', amount: 1, units: ''},
                 eclss: {type: 'eclss', amount: 1, units: ''},
-                powerGeneration: {type: 'solar_pv_array_mars', amount: 300, units: ''},
+                powerGeneration: {type: 'solar_pv_array_mars', amount: 500, units: ''},
                 powerStorage: {type: 'power_storage', amount: 1000, units: 'kWh'},
                 greenhouse: {type: 'greenhouse_small', amount: 1, units: ''},
                 plantSpecies: [


### PR DESCRIPTION
This PR matches a backend PR of the same name.

Only one change: the 4-human-garden preset needs more solar with the new light mechanism.