### PR TITLE
Remove config wizard Layout view for B2

### DIFF
--- a/src/components/base/BaseConfiguration.vue
+++ b/src/components/base/BaseConfiguration.vue
@@ -36,7 +36,8 @@ menu button being present on other unrelated configurations.
               reference entry appearing on the right side.
             -->
             <nav class="configuration-options reference-options">
-                <div :class="{'option-item-active' : activeReference === 'Layout'}"
+                <div v-if="simLocation === 'mars'"
+                     :class="{'option-item-active' : activeReference === 'Layout'}"
                      class="option-item" @click="activeReference = 'Layout'">LAYOUT</div>
                 <div :class="{'option-item-active' : activeReference === 'Graphs'}"
                      class="option-item" @click="activeReference = 'Graphs'">GRAPHS</div>
@@ -61,12 +62,15 @@ menu button being present on other unrelated configurations.
 import {mapState, mapGetters, mapMutations} from 'vuex'
 import {storeToRefs} from 'pinia'
 import {useWizardStore} from '../../store/modules/WizardStore'
+import {useDashboardStore} from '../../store/modules/DashboardStore'
 
 export default {
     setup() {
         const wizard = useWizardStore()
+        const dashboard = useDashboardStore()
+        const {simLocation} = storeToRefs(dashboard)
         const {activeConfigType, activeReference} = storeToRefs(wizard)
-        return {activeConfigType, activeReference}
+        return {activeConfigType, activeReference, simLocation}
     },
 }
 </script>

--- a/src/store/modules/WizardStore.js
+++ b/src/store/modules/WizardStore.js
@@ -536,7 +536,7 @@ export const useWizardStore = defineStore('WizardStore', {
         resetConfigDefault(value) {
             this.configuration = value === 'b2' ? this.defaultB2Config : this.defaultConfig
             this.activeFormIndex = 0
-            this.activeReference = 'Layout'
+            this.activeReference = value === 'mars' ? 'Layout' : 'Reference'
             this.activeRefEntry = 'Welcome'
         },
     },


### PR DESCRIPTION
This PR removes the (3D) Layout view from the config wizard when B2 is selected.
The Habitat view panel has been removed already in a previous PR.