### PR TITLE
Fix value of the fullscreen var passed to panels.

### DIFF
--- a/src/components/dashboard/Main.vue
+++ b/src/components/dashboard/Main.vue
@@ -45,7 +45,7 @@ The layout of each panel is defined in BasePanel.vue to avoid duplication.
             </template>
             <template #panel-content>
                 <component :is="panelName" :canvas-number="index" :panel-index="index"
-                           :panel-section="panelSection" :fullscreen="isFullscreen"
+                           :panel-section="panelSection" :fullscreen="isFullscreenPanel(index)"
                            @panel-section-changed="updatePanelSection" />
             </template>
         </BasePanel>
@@ -129,6 +129,9 @@ export default {
                 this.fullscreenStatus[index] = 'panel-fullscreen'
             }
             this.closePanelMenu()
+        },
+        isFullscreenPanel(index) {
+            return this.fullscreenStatus[index] === 'panel-fullscreen'
         },
 
         openPanelMenu(index) {


### PR DESCRIPTION
While working on optimizing the fullscreen panels, I found the following bug:
* `dashboard/Main.vue` sets the `isFullscreen` var to `true` whenever *any* panel is fullscreen.  This was intentional, since in most cases we only care if there is a fullscreen panel or not.
* The `isFullscreen` var is passed down to each panel, and some panels use the value of the var to determine whether the panel should display 24 or all steps.
* This information is then passed down to the graphs, that react accordingly.

This bug has no visible effect since only one panel can be fullscreen at a time, but the fact that the number of steps passed down to the graph changed triggered unnecessary queries to retrieve a different number of steps for a graph/panel that wasn't even active.

This PR fixes the issue by passing `true` only to the actual panel that is fullscreen, and not to the hidden ones.