### PR TITLE
Fix implementation of the `parseData` function.

### DIFF
--- a/src/javascript/parseData.js
+++ b/src/javascript/parseData.js
@@ -46,7 +46,15 @@ export const parseData = (data, path) => {
                 return output
             } else {
                 // Return the sum of all entries (value only)
-                return Object.values(output).reduce((a, b) => a + b)
+                const values = Object.values(output)
+                if (typeof values[0] === 'object') {
+                    // for arrays, combine the elements so that e.g. [0,1,2] + [3,4,5] == [3,5,7]
+                    return values.reduce((acc, array) => acc.map((sum, i) => sum + array[i]),
+                                         new Array(values[0].length).fill(0))
+                } else {
+                    // otherwise just add together all the values
+                    return values.reduce((a, b) => a + b)
+                }
             }
         } else if (Object.keys(data).includes(index)) {
             // Single Key


### PR DESCRIPTION
This PR fixes a bug in the implementation of the `parseData` function:
https://github.com/overthesun/simoc-web/blob/cfdfe0a3b27fbe363cb0c715956295a4e35b5e68/src/javascript/parseData.js#L43-L50

The last branch (the `else`) only works when the values are numeric, but in some cases the values are arrays, e.g. in:
![image](https://user-images.githubusercontent.com/25624924/215238686-6e2caf2b-81db-4850-9337-abaf1666b079.png)

In this case the branch above tries to add arrays together, and by default JS ends up concatenating the string representation of the arrays, resulting in a long string of comma-separated values:
![image](https://user-images.githubusercontent.com/25624924/215238762-4184a077-02d3-4c26-aec6-dd630eefba08.png)

The correct behavior would be to add together the values for each step of each array, resulting in a new array with the same number of steps.  The Python implementation of the same function already does something similar:
https://github.com/overthesun/simoc/blob/1033e48e6ca1b838144f81e79aa3d6e79c23ae82/agent_model/util.py#L231-L239

This fix does the equivalent operation in JS.