### PR TITLE
Skip end-of-sim survey in development mode.

### DIFF
--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -46,7 +46,8 @@ export default {
                 })
             }
             // Prompt user to take the feedback survey *only* the first time (per session)
-            if (!this.getSurveyWasPrompted && this.currentMode !== 'kiosk') {
+            if (!this.getSurveyWasPrompted && this.currentMode !== 'kiosk' &&
+                import.meta.env.MODE !== 'development') {
                 this.showSurvey({prompt: true, onUnload: confirmExit})
             } else {
                 confirmExit()


### PR DESCRIPTION
This PR skips the end-of-sim survey in development mode, saving a click after each sim and preventing accidental survey submissions.