### PR TITLE
Bump frontend version to 1.3.0 for B2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.2.1",
         "@fortawesome/fontawesome-svg-core": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "vite --host --port 8080",


### PR DESCRIPTION
This PR bumps the frontend version to 1.3.0 for B2.