### PR TITLE
Fix background image for B2

### DIFF
--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -1,5 +1,6 @@
 <template>
-    <div :class="{'waiting': awaiting_response}" class="base-configuration-wrapper" :style="{ 'background-image': 'url(' + bgImage + ')' }">
+    <div :class="{'waiting': awaiting_response}" class="base-configuration-wrapper" :style="{
+        'background-image': 'url(' + bgImage + ')' }">
         <TheTopBar />
         <!-- Show the configuration menu component when getMenuActive is true. -->
         <ConfigurationMenu v-if="menuActive" />
@@ -138,10 +139,11 @@ export default {
         }
     },
     computed: {
+        // Returns the imported static urls for the page backgrounds of mars and earth
         bgImage() {
             if (this.simLocation === 'b2') {
                 return b2Url
-            } else if (this.simLocation === 'mars') {
+            } else {
                 return marsUrl
             }
         },

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,6 +1,5 @@
 <template>
-    <div class="base-dashboard-wrapper" :style="{'backgroundImage':
-        'url(../src/assets/' + simLocation + '-bg.jpg)'}">
+    <div class="base-dashboard-wrapper" :style="{ 'background-image': 'url(' + bgImage + ')' }">
         <router-view />
     </div>
 </template>
@@ -16,6 +15,8 @@ import {idleMixin} from '../javascript/mixins'
 import {useDashboardStore} from '../store/modules/DashboardStore'
 import {useWizardStore} from '../store/modules/WizardStore'
 import {useLiveStore} from '../store/modules/LiveStore'
+import b2Url from '@/assets/b2-bg.jpg'
+import marsUrl from '@/assets/mars-bg.jpg'
 
 export default {
     mixins: [idleMixin],
@@ -95,6 +96,14 @@ export default {
         // getters from the vuex stores
         ...mapGetters(['getGameID']),
         ...mapGetters('modal', ['getSurveyWasPrompted', 'getCountdownEnded']),
+        // Returns the imported static urls for the page backgrounds of mars and earth
+        bgImage() {
+            if (this.simLocation === 'b2') {
+                return b2Url
+            } else {
+                return marsUrl
+            }
+        },
     },
 
     watch: {


### PR DESCRIPTION
When deployed to Beta, Vite was not creating static URLs for the B2 background image. By importing the URLs specifically and returning them from a computed property, I was able to get Vite to recognize them and resolve the issue.