### PR TITLE
popup message when downloading b2 simdata

### DIFF
--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -260,9 +260,10 @@ export default {
             if (preset_name in presets) {
                 let data
                 try {
-                    if (this.simLocation == 'b2') {
+                    if (this.simLocation === 'b2') {
                         this.SETMODALPARAMS({
-                            message: 'Downloading simulation data.\nPlease wait, this could take a few seconds...',
+                            message: 'Downloading simulation data.\n' +
+                                     'Please wait, this could take a few seconds...',
                         })
                         this.SETMODALACTIVE(true)
                     }


### PR DESCRIPTION
Adds a modal window above the configuration when fetching b2 simdata. When testing on beta, this took us 15 seconds - 2 minutes.

In a future update (after vuetify) make this a loading bar or spinner, estimate how much time left.
<img width="775" alt="image" src="https://user-images.githubusercontent.com/50287275/222328209-d0a3da3c-cab6-4361-8cca-0465f2ff806a.png">
