### PR TITLE
Download gzipped simdata instead of json ones

### DIFF
--- a/.github/workflows/build-frontend-prod.yml
+++ b/.github/workflows/build-frontend-prod.yml
@@ -28,7 +28,7 @@ jobs:
           cd public
           mkdir simdata
           cd simdata
-          wget -r -nH --cut-dirs=2 --no-parent --accept="*.json" -erobots=off -q https://simoc.space/download/simdata/
+          wget -r -nH --cut-dirs=2 --no-parent --accept="*.gz" -erobots=off -q https://simoc.space/download/simdata/
           ls
       - name: Download skybox
         run: |

--- a/run.sh
+++ b/run.sh
@@ -11,13 +11,13 @@ fi
 echo '* Updating/downloading simdata/models/skybox files...'
 cd public
 wget -c -r -erobots=off -q -nH --cut-dirs=1 --no-parent \
-    --accept="*.json,*.glb,*.jpg" \
+    --accept="*.gz" \
     https://simoc.space/download/simdata/
 echo '* Simdata files downloaded to <public/simdata>'
 cd ..
 cd src/assets
 wget -c -r -erobots=off -q -nH --cut-dirs=1 --no-parent \
-    --accept="*.json,*.glb,*.jpg" \
+    --accept="*.glb,*.jpg" \
     https://simoc.space/download/models/ \
     https://simoc.space/download/skybox/
 echo '* Models and skybox files downloaded to <src/assets>'


### PR DESCRIPTION
This PR updates `run.sh` and the workflow file to download the gzipped simdata instead of the json ones.