### PR TITLE
add .gz to filename in preset simdata request

### DIFF
--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -223,7 +223,7 @@ export default {
                 // Retrieve simdata file from the backend
                 const fname = preset.simdata_file.split('.')[0]
                 console.log(`* Loading cached <${fname}> simdata ...`)
-                const response = await axios.get(`/simdata/${fname}.json`)
+                const response = await axios.get(`/simdata/${fname}.json.gz`)
                 return response.data  // get the actual data out of the response object
             } catch (error) {
                 console.log('* Loading cached simdata failed, falling back on regular request')


### PR DESCRIPTION
The preset files weren't loading properly locally, and this fixed the problem for me. Would be good for someone else to confirm.

It seems ngs.simoc.space is still requesting the .json version, so that's why it's working. Either we made the change to `.gz` after it was deployed, or it still has the `.json` files available to be sent.