### PR TITLE
Update live (sensor) panels to support full screen mode.

### DIFF
--- a/src/components/graphs/AveragesGraph.vue
+++ b/src/components/graphs/AveragesGraph.vue
@@ -48,6 +48,8 @@ export default {
         color: {type: String, required: true},
         unit: {type: String, required: true},
         currencySensorInfo: {type: Object, required: true},
+        fullscreen: {type: Boolean, default: false},
+        nsteps: {type: Number, required: true},
     },
     setup() {
         const dashboard = useDashboardStore()
@@ -76,6 +78,10 @@ export default {
         },
         currencySensorInfo() {
             this.updateActiveSensors()
+            this.initChart()
+        },
+        // re-init the chart when we change the number of steps displayed
+        nsteps() {
             this.initChart()
         },
     },
@@ -107,7 +113,7 @@ export default {
                     : sensor_id
                 return {
                     lineTension: 0,
-                    data: Array(10),
+                    data: Array(this.nsteps),
                     label: name,
                     borderColor: colors[i],
                     fill: false,
@@ -118,7 +124,7 @@ export default {
                 type: 'line',
                 data: {
                     // fill with '' so that at the beginning the labels don't show undefined
-                    labels: Array(10).fill(''),
+                    labels: Array(this.nsteps).fill(''),
                     // TODO: Create total number of datasets equal to total number of CO2 sensors
                     datasets: datasets,
                 },
@@ -166,14 +172,14 @@ export default {
             const currentStep = this.currentStepBuffer
             const {data} = this.chart
             // if the currentStep is not prevStep + 1 (e.g. when the user moved the scrubber)
-            // we need to redraw the previous 10 steps, otherwise we just add one step
+            // we need to redraw the previous nsteps steps, otherwise we just add one step
             let startingStep
             if (currentStep !== this.prevStep + 1) {
-                startingStep = currentStep - 10  // replace all 10 values
+                startingStep = currentStep - this.nsteps  // replace all nsteps values
             } else {
                 startingStep = currentStep  // add the latest value
             }
-            // this will do 1 or 10 iterations (maybe refactor it to something better)
+            // this will do 1 or nsteps iterations (maybe refactor it to something better)
             for (let step = startingStep; step <= currentStep; step++) {
                 // remove the oldest values
                 data.datasets.forEach(set => set.data.shift())
@@ -194,7 +200,7 @@ export default {
                     data.labels.push(step)
                 } else {
                     // for steps <= 0 use undefined as values and '' as labels
-                    // so that the plot still has 10 total items and is not stretched
+                    // so that the plot still has nsteps total items and is not stretched
                     data.datasets.forEach(set => set.data.push(undefined))
                     data.labels.push('')
                 }

--- a/src/components/panels/AtmosphericCO2.vue
+++ b/src/components/panels/AtmosphericCO2.vue
@@ -9,7 +9,8 @@
         <div>
             <AveragesGraph :id="'canvas-pc-' + canvasNumber" :plotted-value="location"
                            :currency="currency" :color="'#e6194b'" :unit="' ppm'"
-                           :currency-sensor-info="currencySensorInfo" />
+                           :currency-sensor-info="currencySensorInfo"
+                           :fullscreen="fullscreen" :nsteps="fullscreen?600:60" />
         </div>
     </div>
 </template>
@@ -33,6 +34,7 @@ export default {
         // determine the panel index and the selected graph
         panelIndex: {type: Number, required: true},
         panelSection: {type: String, default: null},
+        fullscreen: {type: Boolean, default: false},
     },
     emits: ['panel-section-changed'],
     setup() {

--- a/src/components/panels/AtmosphericO2.vue
+++ b/src/components/panels/AtmosphericO2.vue
@@ -9,7 +9,8 @@
         <div>
             <AveragesGraph :id="'canvas-pc-' + canvasNumber" :plotted-value="location"
                            :currency="currency" :color="'#3cb44b'" :unit="'%'"
-                           :currency-sensor-info="currencySensorInfo" />
+                           :currency-sensor-info="currencySensorInfo"
+                           :fullscreen="fullscreen" :nsteps="fullscreen?600:60" />
         </div>
     </div>
 </template>
@@ -33,6 +34,7 @@ export default {
         // determine the panel index and the selected graph
         panelIndex: {type: Number, required: true},
         panelSection: {type: String, default: null},
+        fullscreen: {type: Boolean, default: false},
     },
     emits: ['panel-section-changed'],
     setup() {

--- a/src/components/panels/RelativeHumidity.vue
+++ b/src/components/panels/RelativeHumidity.vue
@@ -9,7 +9,8 @@
         <div>
             <AveragesGraph :id="'canvas-pc-' + canvasNumber" :plotted-value="location"
                            :currency="currency" :color="'#46f0f0'" :unit="'%'"
-                           :currency-sensor-info="currencySensorInfo" />
+                           :currency-sensor-info="currencySensorInfo"
+                           :fullscreen="fullscreen" :nsteps="fullscreen?600:60" />
         </div>
     </div>
 </template>
@@ -33,6 +34,7 @@ export default {
         // determine the panel index and the selected graph
         panelIndex: {type: Number, required: true},
         panelSection: {type: String, default: null},
+        fullscreen: {type: Boolean, default: false},
     },
     emits: ['panel-section-changed'],
     setup() {

--- a/src/components/panels/Temperature.vue
+++ b/src/components/panels/Temperature.vue
@@ -9,7 +9,8 @@
         <div>
             <AveragesGraph :id="'canvas-pc-' + canvasNumber" :plotted-value="location"
                            :currency="currency" :color="'#b6ff87'" :unit="' °C'"
-                           :currency-sensor-info="currencySensorInfo" />
+                           :currency-sensor-info="currencySensorInfo"
+                           :fullscreen="fullscreen" :nsteps="fullscreen?600:60" />
         </div>
     </div>
 </template>
@@ -33,6 +34,7 @@ export default {
         // determine the panel index and the selected graph
         panelIndex: {type: Number, required: true},
         panelSection: {type: String, default: null},
+        fullscreen: {type: Boolean, default: false},
     },
     emits: ['panel-section-changed'],
     setup() {

--- a/src/store/modules/WizardStore.js
+++ b/src/store/modules/WizardStore.js
@@ -456,7 +456,6 @@ export const useWizardStore = defineStore('WizardStore', {
             this.setConfiguration(preset, location)
         },
         setLiveConfig(duration, location) {
-            console.log('Updating mission time...')
             this.setConfiguration(duration, location)
         },
         setInitial(value) {


### PR DESCRIPTION
This PR updates the live (sensor) panels to support full screen mode.
They now show the values for the last 60s (1m) by default, and 600s (10m) when in full screen.