### PR TITLE
Show timestamp instead of step num in live graphs.

### DIFF
--- a/src/components/graphs/AveragesGraph.vue
+++ b/src/components/graphs/AveragesGraph.vue
@@ -56,8 +56,8 @@ export default {
         const liveStore = useLiveStore()
         const {currentStepBuffer} = storeToRefs(dashboard)
         const {sensorInfo} = storeToRefs(liveStore)
-        const {getReadings} = liveStore
-        return {currentStepBuffer, sensorInfo, getReadings}
+        const {getReadings, getTimestamp} = liveStore
+        return {currentStepBuffer, sensorInfo, getReadings, getTimestamp}
     },
     data() {
         return {
@@ -96,6 +96,10 @@ export default {
             } else {
                 this.activeSensors = [this.plottedValue]
             }
+        },
+        stepnum2timestamp(step) {
+            const time = this.getTimestamp(step)
+            return (time === undefined) ? '00:00:00' : time.time
         },
         initChart() {
             if (this.chart) {
@@ -197,7 +201,7 @@ export default {
                         data.datasets[i].data.push(value)
                     })
                     // add the new values
-                    data.labels.push(step)
+                    data.labels.push(this.stepnum2timestamp(step))
                 } else {
                     // for steps <= 0 use undefined as values and '' as labels
                     // so that the plot still has nsteps total items and is not stretched

--- a/src/store/modules/LiveStore.js
+++ b/src/store/modules/LiveStore.js
@@ -84,7 +84,6 @@ export const useLiveStore = defineStore('LiveStore', {
          *  the entire object and destructuring it in the associated variable mutator.
          */
         parseData(bundles) {
-            console.log(bundles)
             this.setDataBundles(bundles)
 
             bundles.forEach(item => {

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -268,7 +268,6 @@ export default {
                 this.socket.emit('send-step-data')
             })
             socket.on('step-batch', data => {
-                console.log(`Received a bundle from the server:`)
                 // If initBundleNum is null set it to the first n sent in the bundle of data.
                 // This indicates that a client has made an initial connection to the live dashboard.
                 if (this.initBundleNum === null) {


### PR DESCRIPTION
This PR updates the `AveragesGraph` (only used in live mode) to show the timestamp on the x axis instead of the bundle number:
![image](https://user-images.githubusercontent.com/25624924/233608797-9f6ab6a4-9f66-4aa4-ae8c-c0538e156d82.png)
