### PR TITLE
update threejs lighting

### DIFF
--- a/src/threejs/systems/lights.js
+++ b/src/threejs/systems/lights.js
@@ -1,12 +1,12 @@
 import * as THREE from 'three'
 
 const buildLights = (settings, scene) => {
-    const directLight = new THREE.DirectionalLight('white', 3)
+    const directLight = new THREE.DirectionalLight('white', 3/Math.PI)
     directLight.position.set(10, 20, 15)
     if (settings.shadows) {
         directLight.castShadow = true
     }
-    const ambientLight = new THREE.AmbientLight('white', 1)
+    const ambientLight = new THREE.AmbientLight('white', 1/Math.PI)
 
     const lights = new THREE.Group()
     lights.add(directLight, ambientLight)

--- a/src/threejs/systems/renderer.js
+++ b/src/threejs/systems/renderer.js
@@ -5,7 +5,6 @@ const buildRenderer = (containerId, settings) => {
         antialias: settings.antialias,
     })
 
-    renderer.physicallyCorrectLights = true
     if (settings.shadows) {
         renderer.shadowMap.enabled = true
     }


### PR DESCRIPTION
Big package update for ThreeJS: https://discourse.threejs.org/t/updates-to-lighting-in-three-js-r155/53733

They've deprecated `physicallyCorrectLights`, and their suggested simple solution is to divide light intensity by Pi. Tested and everything looks the same.