### PR TITLE
Group fortawesome deps in dependabot.yml.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       interval: "daily"
     assignees:
       - "ezio-melotti"
+    groups:
+      fortawesome:
+        patterns:
+          - "@fortawesome*"
     open-pull-requests-limit: 10
 
   # Maintain dependencies for GitHub Actions


### PR DESCRIPTION
This PR should tell `@dependabot` to group all `fortawesome` dep updates in a single PR.