### PR TITLE
Remember plotted items in the Levels graph.

### DIFF
--- a/src/components/dashboard/Main.vue
+++ b/src/components/dashboard/Main.vue
@@ -8,7 +8,7 @@ The layout of each panel is defined in BasePanel.vue to avoid duplication.
 
 <template>
     <div :class="{'dashboard-onepanel': isFullscreen}" class="dashboard-view-wrapper">
-        <BasePanel v-for="([panelName, panelSection], index) in activePanels.map(p => p.split(':'))"
+        <BasePanel v-for="([panelName, panelSection, plottedItems], index) in activePanels.map(p => p.split(':'))"
                    :key="index" :class="fullscreenStatus[index]">
             <template #panel-title><div class="panel-title">{{panels[panelName].panelTitle}}</div></template>
             <template #panel-menu>
@@ -45,7 +45,8 @@ The layout of each panel is defined in BasePanel.vue to avoid duplication.
             </template>
             <template #panel-content>
                 <component :is="panelName" :canvas-number="index" :panel-index="index"
-                           :panel-section="panelSection" :fullscreen="isFullscreenPanel(index)"
+                           :panel-section="panelSection" :plotted-items="plottedItems"
+                           :fullscreen="isFullscreenPanel(index)"
                            @panel-section-changed="updatePanelSection" />
             </template>
         </BasePanel>
@@ -162,10 +163,10 @@ export default {
             this.getActivePanels = this.activePanels
             this.closePanelMenu()
         },
-        updatePanelSection(index, section) {
+        updatePanelSection(index, section, plottedItems) {
             // update the section of the panel at index
             const panelName = this.activePanels[index].split(':')[0]
-            this.activePanels[index] = [panelName, section].join(':')
+            this.activePanels[index] = [panelName, section, plottedItems].join(':')
             this.getActivePanels = this.activePanels
         },
         removePanel(index) {

--- a/src/components/graphs/LevelsGraph.vue
+++ b/src/components/graphs/LevelsGraph.vue
@@ -24,6 +24,7 @@ export default {
     props: {
         id: {type: String, required: true},
         plottedStorage: {type: String, required: true},
+        plottedItems: {type: String, default: undefined},
         storagesMapping: {type: Object, required: true},  // TODO: Revert ABM Workaround
         fullscreen: {type: Boolean, default: false},
         nsteps: {type: Number, required: true},
@@ -75,6 +76,10 @@ export default {
         plottedStorage() {
             this.initChart()
         },
+        // re-init the chart when we plot something else
+        plottedItems() {
+            this.initChart()
+        },
         // re-init the chart when we change the number of steps displayed
         nsteps() {
             this.initChart()
@@ -89,6 +94,7 @@ export default {
         // TODO: this code is very similar to VersusGraph.vue
         initChart() {
             this.storage_name = this.plottedStorage
+            this.plotted_items = this.plottedItems?.split('|')
             this.storage_type = this.storagesMapping[this.storage_name]
             if (this.chart) {
                 // when switching chart we have to destroy
@@ -111,6 +117,7 @@ export default {
                             backgroundColor: color,
                             fill: true,
                             pointStyle: 'line',
+                            hidden: this.plotted_items !== undefined && !this.plotted_items.includes(label),
                         })
                     ),
                 },
@@ -143,6 +150,15 @@ export default {
                             labels: {
                                 boxWidth: 20,
                             },
+                            onClick: (event, legendItem, legend) => {
+                                legend.chart.setDatasetVisibility(
+                                    legendItem.datasetIndex,
+                                    !legend.chart.isDatasetVisible(legendItem.datasetIndex)
+                                )
+                                legend.chart.update()
+                                const plotted_items = legend.legendItems.filter(item => !item.hidden).map(item => item.text).join('|')
+                                this.$emit('plotted-items-changed', plotted_items)
+                            }
                         },
                         tooltip: {
                             mode: 'index', // show both values

--- a/src/components/panels/StorageRatios.vue
+++ b/src/components/panels/StorageRatios.vue
@@ -7,9 +7,11 @@
             </option>
         </select>
         <div>
-            <LevelsGraph :id="'canvas-storage-levels-' + canvasNumber" :plotted-storage="storage"
+            <LevelsGraph :id="'canvas-storage-levels-' + canvasNumber"
+                         :plotted-storage="storage" :plotted-items="plottedItems"
                          :storages-mapping="storagesMapping" :fullscreen="fullscreen"
-                         :nsteps="fullscreen?getTotalMissionHours:24" />
+                         :nsteps="fullscreen?getTotalMissionHours:24"
+                         @plotted-items-changed="updatePlottedItems" />
         </div>
     </div>
 </template>
@@ -33,6 +35,7 @@ export default {
         // determine the panel index and the selected graph
         panelIndex: {type: Number, required: true},
         panelSection: {type: String, default: null},
+        plottedItems: {type: String, default: null},
         fullscreen: {type: Boolean, default: false},
     },
     emits: ['panel-section-changed'],
@@ -58,9 +61,12 @@ export default {
         },
     },
     watch: {
-        storage() {
+        storage(newVal, oldVal) {
             // tell dashboard/Main.vue that we changed panel section,
             // so that it can update the list of activePanels
+            if (oldVal === undefined) {
+                return  // don't emit when loading the panel for the first time
+            }
             this.$emit('panel-section-changed', this.panelIndex, this.storage)
         },
         getActivePanels() {
@@ -83,6 +89,11 @@ export default {
     },
     methods: {
         stringFormatter: StringFormatter,
+
+        updatePlottedItems(plottedItems) {
+            console.log('emitting panel-section-changed from updatePlottedItems', this.panelIndex, this.storage, plottedItems)
+            this.$emit('panel-section-changed', this.panelIndex, this.storage, plottedItems)
+        },
     },
 }
 </script>


### PR DESCRIPTION
This PR updates the StorageRatios and LevelGraph to remember which items are plotted within the graph.

This is useful because it allows us (and the user) to e.g. save a panel layout where only CO2 and O2 are visible in the graph, and the other gases are hidden by default.

This is still a proof of concept, as there are a couple of things left to do (possible in separate PRs):

- [ ] update all other graphs/panels to support this feature
- [ ] refactor the code to avoid duplication in each graph/panel