### PR TITLE
Simplify dropdown check in the Sensor Readings panel.

### DIFF
--- a/src/components/panels/LiveSensors.vue
+++ b/src/components/panels/LiveSensors.vue
@@ -128,7 +128,6 @@ export default {
         },
         getValidInfo() {
             const sensor_id = this.getSensorId()
-            console.log(sensor_id)
             if (!Object.keys(this.sensorInfo).includes(sensor_id)) {
                 return {}
             }

--- a/src/components/panels/LiveSensors.vue
+++ b/src/components/panels/LiveSensors.vue
@@ -128,7 +128,8 @@ export default {
         },
         getValidInfo() {
             const sensor_id = this.getSensorId()
-            if (sensor_id === undefined || !Object.keys(this.sensorInfo).length) {
+            console.log(sensor_id)
+            if (!Object.keys(this.sensorInfo).includes(sensor_id)) {
                 return {}
             }
             return this.sensorInfo[sensor_id].reading_info


### PR DESCRIPTION
This didn't work correctly in some situations but it's now fixed.
The sensor dropdown should still just show the available sensors for the selected hosts, but since all hosts should have the same sensors it's not a priority for now.