### PR TITLE
Improve graph line style for live mode panels.

### DIFF
--- a/src/components/graphs/AveragesGraph.vue
+++ b/src/components/graphs/AveragesGraph.vue
@@ -116,12 +116,12 @@ export default {
                     ? this.currencySensorInfo[sensor_id].sensor_name
                     : sensor_id
                 return {
-                    lineTension: 0,
                     data: Array(this.nsteps),
                     label: name,
                     borderColor: colors[i],
-                    fill: false,
-                    pointStyle: 'line',
+                    borderWidth: 2,
+                    cubicInterpolationMode: 'monotone',
+                    pointStyle: false,
                 }
             })
             this.chart = new Chart(canvas, {
@@ -156,14 +156,17 @@ export default {
                         legend: {
                             display: true,
                             position: 'bottom',
-                            // https://stackoverflow.com/a/50450646
-                            labels: {usePointStyle: true},
+                            labels: {
+                                usePointStyle: true,
+                                pointStyle: 'line',
+                            },
                         },
                         tooltip: {
                             mode: 'index', // show both values
                             intersect: false,
                             usePointStyle: true,
                             callbacks: {
+                                labelPointStyle: () => ({pointStyle: 'line'}),
                                 title: context => `Step: ${context[0].label}`,
                             },
                         },

--- a/src/components/graphs/LiveReadings.vue
+++ b/src/components/graphs/LiveReadings.vue
@@ -127,12 +127,12 @@ export default {
                     labels: Array(this.nsteps).fill(''),
                     // TODO: Create total number of datasets equal to total number of CO2 sensors
                     datasets: [{
-                        lineTension: 0,
                         data: Array(this.nsteps),
                         label: `${this.hostname}.${this.sensorname}`,
                         borderColor: colors[0],
-                        fill: false,
-                        pointStyle: 'line',
+                        borderWidth: 2,
+                        cubicInterpolationMode: 'monotone',
+                        pointStyle: false,
                     }],
                 },
                 options: {
@@ -159,14 +159,18 @@ export default {
                         legend: {
                             display: true,
                             position: 'bottom',
-                            // https://stackoverflow.com/a/50450646
-                            labels: {usePointStyle: true},
+                            labels: {
+                                usePointStyle: true,
+                                pointStyle: 'line',
+                            },
                         },
                         tooltip: {
                             mode: 'index', // show both values
                             intersect: false,
                             usePointStyle: true,
+                            pointStyle: 'line',
                             callbacks: {
+                                labelPointStyle: () => ({pointStyle: 'line'}),
                                 title: context => `Step: ${context[0].label}`,
                             },
                         },

--- a/src/components/graphs/LiveReadings.vue
+++ b/src/components/graphs/LiveReadings.vue
@@ -168,7 +168,6 @@ export default {
                             mode: 'index', // show both values
                             intersect: false,
                             usePointStyle: true,
-                            pointStyle: 'line',
                             callbacks: {
                                 labelPointStyle: () => ({pointStyle: 'line'}),
                                 title: context => `Step: ${context[0].label}`,


### PR DESCRIPTION
This PR improves the style of the graph lines for live mode panels, especially when they are in full screen.  It partially addresses #645.

Before:
![line-style-1](https://github.com/overthesun/simoc-web/assets/25624924/c1571b81-1b42-48df-b1d7-219a10d98f49)
After:
![line-style-0](https://github.com/overthesun/simoc-web/assets/25624924/4f112933-5f98-43e7-89aa-535b86cdcf95)

---

Before/after side-by-side:
![line-style-2](https://github.com/overthesun/simoc-web/assets/25624924/6f9c43c9-5c8b-4b79-9ed3-a06c46e2b052)

---

Before (except top-right panel):
![line-style-3](https://github.com/overthesun/simoc-web/assets/25624924/46385a98-e612-4d26-aaab-b2e2e03d8043)

After:
![line-style-4](https://github.com/overthesun/simoc-web/assets/25624924/9fff712e-705b-469c-858e-9327c067e8a0)

---

Before:
![line-style-5](https://github.com/overthesun/simoc-web/assets/25624924/e0fc7231-eb29-441a-8b4d-09192589d89e)
After:
![line-style-6](https://github.com/overthesun/simoc-web/assets/25624924/e168b77f-fae8-4274-a3a6-044c0db60417)

---

See inline comments for further info.