### PR TITLE
Improve graph line style for sim mode panels.

### DIFF
--- a/src/components/graphs/AgentGraph.vue
+++ b/src/components/graphs/AgentGraph.vue
@@ -185,13 +185,13 @@ export default {
                 const allUnits = new Set(Object.values(datasetsData).map(d => d.unit))
                 this.unit = allUnits.size === 1 ? allUnits.values().next().value : ''
                 datasets = Object.values(datasetsData).map(({unit, label}, i) => ({
-                    lineTension: 0,
                     data: Array(this.nsteps),
                     label: label + ((unit && !this.unit) ? ` (${unit})` : ''),
                     // TODO: Get field-specific color from currencyDict or fieldDict
                     borderColor: this.colors[i],
-                    fill: false,
-                    pointStyle: 'line',
+                    borderWidth: 2,
+                    cubicInterpolationMode: 'monotone',
+                    pointStyle: false,
                 }))
             }
 
@@ -232,14 +232,17 @@ export default {
                         legend: {
                             display: true,
                             position: 'bottom',
-                            // https://stackoverflow.com/a/50450646
-                            labels: {usePointStyle: true},
+                            labels: {
+                                usePointStyle: true,
+                                pointStyle: 'line',
+                            },
                         },
                         tooltip: {
                             mode: 'index', // show both values
                             intersect: false,
                             usePointStyle: true,
                             callbacks: {
+                                labelPointStyle: () => ({pointStyle: 'line'}),
                                 title: context => `Step: ${context[0].label}`,
                             },
                         },

--- a/src/components/graphs/LevelsGraph.vue
+++ b/src/components/graphs/LevelsGraph.vue
@@ -105,12 +105,13 @@ export default {
                     // create N datasets with different labels/colors
                     datasets: this.setsinfo[this.storage_type].labels_colors.map(
                         ([label, color]) => ({
-                            lineTension: 0,
                             data: Array(this.nsteps),
                             label: label,
                             backgroundColor: color,
+                            borderWidth: 2,
+                            cubicInterpolationMode: 'monotone',
+                            pointStyle: false,
                             fill: true,
-                            pointStyle: 'line',
                         })
                     ),
                 },

--- a/src/components/graphs/VersusGraph.vue
+++ b/src/components/graphs/VersusGraph.vue
@@ -84,20 +84,20 @@ export default {
                     labels: Array(this.nsteps).fill(''),
                     datasets: [
                         {
-                            lineTension: 0,
                             data: Array(this.nsteps),
                             label: 'Produced',
                             borderColor: '#0000ff',
-                            fill: false,
-                            pointStyle: 'line',
+                            borderWidth: 2,
+                            cubicInterpolationMode: 'monotone',
+                            pointStyle: false,
                         },
                         {
-                            lineTension: 0,
                             data: Array(this.nsteps),
                             label: 'Consumed',
                             borderColor: '#cd0000',
-                            fill: false,
-                            pointStyle: 'line',
+                            borderWidth: 2,
+                            cubicInterpolationMode: 'monotone',
+                            pointStyle: false,
                         },
                     ],
                 },
@@ -132,13 +132,17 @@ export default {
                             display: true,
                             position: 'bottom',
                             // https://stackoverflow.com/a/50450646
-                            labels: {usePointStyle: true},
+                            labels: {
+                                usePointStyle: true,
+                                pointStyle: 'line',
+                            },
                         },
                         tooltip: {
                             mode: 'index', // show both values
                             intersect: false,
                             usePointStyle: true,
                             callbacks: {
+                                labelPointStyle: () => ({pointStyle: 'line'}),
                                 title: context => `Step: ${context[0].label}`,
                             },
                         },


### PR DESCRIPTION
This PR improves the style of the graph lines for sim mode panels. It partially addresses https://github.com/overthesun/simoc-web/issues/645.  See also #646.

Before:
![line-style-7](https://github.com/overthesun/simoc-web/assets/25624924/fe6801fa-153d-4d32-82fa-828e58c67ebc)

After:
![line-style-8](https://github.com/overthesun/simoc-web/assets/25624924/bd45dc78-8ee7-4d66-878d-580cf3af1cff)

----

Before:
![line-style-9](https://github.com/overthesun/simoc-web/assets/25624924/092ee089-fa50-420c-b355-78076c688882)

After:
![line-style-10](https://github.com/overthesun/simoc-web/assets/25624924/504d9aef-f35d-44e1-9f2f-a0043d95d5a8)

---

Before:
![line-style-11](https://github.com/overthesun/simoc-web/assets/25624924/6a159c40-52cb-42d3-b188-76aab77a629e)

After:
![line-style-12](https://github.com/overthesun/simoc-web/assets/25624924/a700f03c-71d2-4aa8-9c08-b484bd996b1b)
