### PR TITLE
Add additional dashboard panel layouts (1x1, 2x1, 2x2).

### DIFF
--- a/src/components/dashboard/Main.vue
+++ b/src/components/dashboard/Main.vue
@@ -7,7 +7,7 @@ The layout of each panel is defined in BasePanel.vue to avoid duplication.
 -->
 
 <template>
-    <div :class="{'dashboard-onepanel': isFullscreen}" class="dashboard-view-wrapper">
+    <div :class="layoutClass" class="dashboard-view-wrapper">
         <BasePanel v-for="([panelName, panelSection], index) in activePanels.map(p => p.split(':'))"
                    :key="index" :class="fullscreenStatus[index]">
             <template #panel-title><div class="panel-title">{{panels[panelName].panelTitle}}</div></template>
@@ -98,6 +98,18 @@ export default {
         isFullscreen() {
             return this.fullscreenStatus.includes('panel-fullscreen')
         },
+        layoutClass() {
+            // return the CSS class used to determine the panel layout
+            if (this.isFullscreen) {
+                return 'dashboard-1x1'
+            }
+            return {
+                1: 'dashboard-1x1',
+                2: 'dashboard-2x1',
+                3: 'dashboard-2x2',
+                4: 'dashboard-2x2',
+            }[Object.keys(this.activePanels).length] ?? false
+        },
     },
     watch: {
         getActivePanels() {
@@ -179,7 +191,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    .dashboard-view-wrapper{
+    .dashboard-view-wrapper {
         font-family: "Roboto", sans-serif;
         width:100%;
         height:100%;
@@ -195,9 +207,18 @@ export default {
         grid-column-gap: 16px;
         overflow: auto;
     }
-    .dashboard-onepanel {
+    /* force specific layouts when there are few panels */
+    .dashboard-1x1 {
         grid-template-rows: 1fr;
         grid-template-columns: 1fr;
+    }
+    .dashboard-2x1 {
+        grid-template-rows: 1fr 1fr;
+        grid-template-columns: 1fr;
+    }
+    .dashboard-2x2 {
+        grid-template-rows: 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
     }
 
     .panel-menu {


### PR DESCRIPTION
This fixes:
* #709 

As described in the issue, I was able to implement different layouts by keeping the default 3 column layout for all cases except 1, 2, 3, and 4 panels, which now use respectively a 1x1, 2x1, 2x2, and 2x2 layout.  Before this PR they were using a 3 column layout too, with 1 or 2 lines.

The handling of fullscreen panels is now integrated in this too, since the fullscreen panel just uses the same 1x1 layout used when there is only one panel.