### PR TITLE
Fix browser reported entry field issues

### DIFF
--- a/src/components/entry/Login.vue
+++ b/src/components/entry/Login.vue
@@ -25,8 +25,10 @@
             <template #entry-main>
                 <section :class="{'entry-form-active': activeOption==='login'}" class="entry-form entry-form-login">
                     <form v-if="!activeGuestLogin" id="login-form" @submit.prevent="loginUser">
-                        <input v-model="user.username" type="text" class="input-field-text" placeholder="Username">
-                        <input v-model="user.password" type="password" class="input-field-text" placeholder="Password">
+                        <input id="userName" v-model="user.username" type="text"
+                               class="input-field-text" autocomplete="on" placeholder="Username">
+                        <input id="password" v-model="user.password" type="password"
+                               class="input-field-text" placeholder="Password">
                     </form>
                     <p v-else>If you don't want to create an account, you can log in as a Guest.
                         Guest accounts are temporary and will be deleted on a regular basis.</p>
@@ -35,12 +37,12 @@
                 <section :class="{'entry-form-active': activeOption==='register'}"
                          class="entry-form entry-form-register">
                     <form id="register-form" @submit.prevent="registerUser">
-                        <input v-model="register.username" type="text" class="input-field-text"
-                               placeholder="Choose Username">
-                        <input v-model="register.password" type="password" class="input-field-text"
-                               placeholder="Enter Password">
-                        <input v-model="register.confirmPassword" type="password" class="input-field-text"
-                               placeholder="Confirm Password">
+                        <input id="newUserName" v-model="register.username" type="text"
+                               class="input-field-text" placeholder="Choose Username">
+                        <input id="newPassword" v-model="register.password" type="password"
+                               class="input-field-text" placeholder="Enter Password">
+                        <input id="confirmPassword" v-model="register.confirmPassword" type="password"
+                               class="input-field-text" placeholder="Confirm Password">
                     </form>
                 </section>
             </template>

--- a/src/components/entry/Login.vue
+++ b/src/components/entry/Login.vue
@@ -25,7 +25,7 @@
             <template #entry-main>
                 <section :class="{'entry-form-active': activeOption==='login'}" class="entry-form entry-form-login">
                     <form v-if="!activeGuestLogin" id="login-form" @submit.prevent="loginUser">
-                        <input id="userName" v-model="user.username" type="text"
+                        <input id="username" v-model="user.username" type="text"
                                class="input-field-text" autocomplete="on" placeholder="Username">
                         <input id="password" v-model="user.password" type="password"
                                class="input-field-text" placeholder="Password">
@@ -37,11 +37,11 @@
                 <section :class="{'entry-form-active': activeOption==='register'}"
                          class="entry-form entry-form-register">
                     <form id="register-form" @submit.prevent="registerUser">
-                        <input id="newUserName" v-model="register.username" type="text"
+                        <input id="new-username" v-model="register.username" type="text"
                                class="input-field-text" placeholder="Choose Username">
-                        <input id="newPassword" v-model="register.password" type="password"
+                        <input id="new-password" v-model="register.password" type="password"
                                class="input-field-text" placeholder="Enter Password">
-                        <input id="confirmPassword" v-model="register.confirmPassword" type="password"
+                        <input id="confirm-password" v-model="register.confirmPassword" type="password"
                                class="input-field-text" placeholder="Confirm Password">
                     </form>
                 </section>


### PR DESCRIPTION
While I was looking to improve code on my ACE branch and fix "issues" reported by the browser, I cam across these issues from our login page and it looked like an easy fix.

When you attempt to login to SIMOC and look at the browser console, there are issues the browser reports related to the lack of an id or name for each form `<input>` element.  

This screenshot shows how the issue is presented in Chrome:
![b4_fix](https://github.com/overthesun/simoc-web/assets/72905638/60ed2d7a-7fc4-4c9c-9512-fe0cb6279f53)



I added an "id" for each of these fields, as well as 'autocomplete="on"' for the username field, which eliminates all browser reported 'issues' related to the login form, and additionally should make it so that browsers can more reliably use autocomplete for a return user for their username field.

This screenshot shows issues no longer present on the login screeen in Chrome:

![field_id_fix](https://github.com/overthesun/simoc-web/assets/72905638/a28c0db8-afe4-41cf-ac21-e3ef2abf337e)


