### PR TITLE
Fix a build warning about the legacy JS API

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -37,6 +37,12 @@ export default defineConfig({
         assetsDir: 'static',
     },
     css: {
+        preprocessorOptions: {
+            // this section can probably be removed on Vite 6
+            scss: {
+                api: 'modern',
+            },
+        },
         postcss: {
             plugins: [
                 postcssNesting,


### PR DESCRIPTION
This PR is a follow-up of
* #858 
* #860 

and replaces
* #853

fixing the warnings about the legacy JS API.