### PR TITLE
Replace deprecated `@import` rules with `@use`

### DIFF
--- a/src/components/base/BaseMenu.vue
+++ b/src/components/base/BaseMenu.vue
@@ -39,5 +39,5 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '../../sass/components/menu';
+@use '../../sass/components/menu';
 </style>

--- a/src/components/configuration/ECLSS.vue
+++ b/src/components/configuration/ECLSS.vue
@@ -140,7 +140,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @import '../../sass/components/configuration-input';
+    @use '../../sass/components/configuration-input';
 
     .list-input {
         margin: 4px 0px 8px 0px;

--- a/src/components/configuration/ECLSS.vue
+++ b/src/components/configuration/ECLSS.vue
@@ -140,9 +140,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @use '../../sass/components/configuration-input';
+@use '../../sass/components/configuration-input';
 
-    .list-input {
-        margin: 4px 0px 8px 0px;
-    }
+.list-input {
+    margin: 4px 0 8px 0;
+}
 </style>

--- a/src/components/configuration/Energy.vue
+++ b/src/components/configuration/Energy.vue
@@ -114,6 +114,6 @@ export default {
 @use '../../sass/components/configuration-input';
 
 .input-field-select{
-    margin-right:24px;
+    margin-right: 24px;
 }
 </style>

--- a/src/components/configuration/Energy.vue
+++ b/src/components/configuration/Energy.vue
@@ -111,7 +111,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '../../sass/components/configuration-input';
+@use '../../sass/components/configuration-input';
 
 .input-field-select{
     margin-right:24px;

--- a/src/components/configuration/Greenhouse.vue
+++ b/src/components/configuration/Greenhouse.vue
@@ -347,25 +347,25 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @use '../../sass/components/configuration-input';
+@use '../../sass/components/configuration-input';
 
-    .input-plant-wrapper{
-        display:flex;
-        justify-content:flex-start;
-        align-items:center;
+.input-plant-wrapper{
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+}
+
+.input-field-select{
+    margin-right: 24px;
+}
+
+.plant-row-icon{
+    &:first-of-type{
+        margin-left: auto;
     }
 
-    .input-field-select{
-        margin-right:24px;
-    }
-
-    .plant-row-icon{
-        &:first-of-type{
-            margin-left:auto;
-        }
-
-        margin-right:24px;
-    }
+    margin-right: 24px;
+}
 
 .crop-mgmt-description{
     display: flex;

--- a/src/components/configuration/Greenhouse.vue
+++ b/src/components/configuration/Greenhouse.vue
@@ -347,7 +347,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @import '../../sass/components/configuration-input';
+    @use '../../sass/components/configuration-input';
 
     .input-plant-wrapper{
         display:flex;

--- a/src/components/configuration/Inhabitants.vue
+++ b/src/components/configuration/Inhabitants.vue
@@ -218,9 +218,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @use '../../sass/components/configuration-input';
+@use '../../sass/components/configuration-input';
 
-    .list-input {
-        margin-top: 0.5em;
-    }
+.list-input {
+    margin-top: 0.5em;
+}
 </style>

--- a/src/components/configuration/Inhabitants.vue
+++ b/src/components/configuration/Inhabitants.vue
@@ -218,7 +218,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @import '../../sass/components/configuration-input';
+    @use '../../sass/components/configuration-input';
 
     .list-input {
         margin-top: 0.5em;

--- a/src/components/configuration/Initial.vue
+++ b/src/components/configuration/Initial.vue
@@ -108,7 +108,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @import '../../sass/components/configuration-input';
+    @use '../../sass/components/configuration-input';
 
     .input-initial-wrapper{
         display:flex;

--- a/src/components/configuration/Initial.vue
+++ b/src/components/configuration/Initial.vue
@@ -108,15 +108,15 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @use '../../sass/components/configuration-input';
+@use '../../sass/components/configuration-input';
 
-    .input-initial-wrapper{
-        display:flex;
-        justify-content: flex-start;
-        align-items:center;
-    }
+.input-initial-wrapper{
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+}
 
-    .input-field-number{
-        margin-right:24px;
-    }
+.input-field-number{
+    margin-right: 24px;
+}
 </style>

--- a/src/components/configuration/Presets.vue
+++ b/src/components/configuration/Presets.vue
@@ -156,7 +156,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '../../sass/components/configuration-input';
+@use '../../sass/components/configuration-input';
 
 .presets-dropdown,
 .custom-preset {

--- a/src/components/menu/Survey.vue
+++ b/src/components/menu/Survey.vue
@@ -147,7 +147,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '../../sass/components/configuration-input';
+@use '../../sass/components/configuration-input';
 
 .question{
     display: flex;

--- a/src/components/menu/Survey.vue
+++ b/src/components/menu/Survey.vue
@@ -183,5 +183,4 @@ export default {
 #menu-buttons{
     margin-top: 32px;
 }
-
 </style>


### PR DESCRIPTION
This PR fixes a series of deprecation warnings that look like:
```
Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
2 │     @import '../../sass/components/configuration-input';
  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    src/components/configuration/Greenhouse.vue 2:13  root stylesheet
```
by replacing `@import` with `@use`.  `@use` creates a namespace, which means variables defined in the CSS being imported need to be prefixed, but since we don't have any variable, a regular replace worked.  While I was at it, I also fixed the style conventions of the affected files to make them more consistent.

This PR fixes all the remaining deprecation warnings, following up on:
* #867 