### PR TITLE
Add a new CardList panel type and an Atmospheric values panel

### DIFF
--- a/src/components/basepanel/CardList.vue
+++ b/src/components/basepanel/CardList.vue
@@ -1,0 +1,53 @@
+<template>
+    <section class="cards-list-wrapper">
+        <ul class="cards-list">
+            <template v-for="(value, desc) in data" :key="`card_${desc}`">
+                <li>
+                    <span>{{desc}}</span>
+                    <span>{{value}}</span>
+                </li>
+            </template>
+        </ul>
+    </section>
+</template>
+
+<script>
+
+export default {
+    name: 'DataDisplay',
+    props: {
+        data: {type: Object, required: true},
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+.cards-list-wrapper {
+    overflow-y: auto;
+    height: 100%;
+}
+.cards-list {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+.cards-list li {
+    font-size: 200%;
+    background-color: #222;
+    border: 1px solid #666;
+    margin: .2em 0;
+    padding: 0 .4em;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex: 1 1 auto;
+}
+.cards-list span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+</style>

--- a/src/components/basepanel/CardList.vue
+++ b/src/components/basepanel/CardList.vue
@@ -50,5 +50,6 @@ export default {
 .cards-list span:first-child {
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
 }
 </style>

--- a/src/components/basepanel/CardList.vue
+++ b/src/components/basepanel/CardList.vue
@@ -14,7 +14,7 @@
 <script>
 
 export default {
-    name: 'DataDisplay',
+    name: 'CardList',
     props: {
         data: {type: Object, required: true},
     },

--- a/src/components/basepanel/CardList.vue
+++ b/src/components/basepanel/CardList.vue
@@ -47,6 +47,9 @@ export default {
     align-items: center;
     flex: 1 1 auto;
 }
+.panel-fullscreen .cards-list li {
+    font-size: 400%;
+}
 .cards-list span:first-child {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/components/basepanel/CardList.vue
+++ b/src/components/basepanel/CardList.vue
@@ -11,8 +11,8 @@
     </section>
 </template>
 
-<script>
 
+<script>
 export default {
     name: 'CardList',
     props: {
@@ -20,6 +20,7 @@ export default {
     },
 }
 </script>
+
 
 <style lang="scss" scoped>
 .cards-list-wrapper {

--- a/src/components/basepanel/index.js
+++ b/src/components/basepanel/index.js
@@ -1,2 +1,3 @@
 export {default as BasePanel} from './BasePanel.vue'
 export {default as DataDisplay} from './DataDisplay.vue'
+export {default as CardList} from './CardList.vue'

--- a/src/components/panels/AtmosphericValues.vue
+++ b/src/components/panels/AtmosphericValues.vue
@@ -34,9 +34,7 @@ export default {
     },
     methods: {
         setActiveData(step) {
-            if (!step) {
-                return
-            }
+            if (!step) return
             // find the agents for crew quarters and greenhouse
             const {agents} = this.gameConfig
             const cq_type = Object.keys(agents).find(key => key.startsWith('crew_habitat'))
@@ -47,9 +45,11 @@ export default {
             storages.forEach(([storage, label]) => {
                 if (!storage) return  // skip storage if it's not defined
                 const tot_atmo = this.getData([storage, 'storage', 'SUM', 1])
+                // find the CO2 amount in ppm
                 const co2_kg = this.getData([storage, 'storage', 'co2', step])
                 const co2_ppm = Math.round(co2_kg / tot_atmo * 1000000)
                 data[`CO₂ ${label}`] = `${co2_ppm}ppm`
+                // find the O2 amount in percentage
                 const o2_kg = this.getData([storage, 'storage', 'o2', step])
                 const o2_perc = o2_kg / tot_atmo * 100
                 data[`O₂ ${label}`] = `${o2_perc.toFixed(2)}%`

--- a/src/components/panels/AtmosphericValues.vue
+++ b/src/components/panels/AtmosphericValues.vue
@@ -8,7 +8,6 @@
 <script>
 import {storeToRefs} from 'pinia'
 import {useDashboardStore} from '../../store/modules/DashboardStore'
-import {StringFormatter} from '../../javascript/utils'
 import {CardList} from '../basepanel'
 
 export default {
@@ -19,9 +18,9 @@ export default {
     modes: ['sim'],
     setup() {
         const dashboard = useDashboardStore()
-        const {humanAtmosphere, currentStepBuffer, currencyDict, gameConfig} = storeToRefs(dashboard)
-        const {getData, getUnit} = dashboard
-        return {humanAtmosphere, currentStepBuffer, getData, currencyDict, gameConfig, getUnit}
+        const {currentStepBuffer, gameConfig} = storeToRefs(dashboard)
+        const {getData} = dashboard
+        return {currentStepBuffer, getData, gameConfig}
     },
     data() {
         return {
@@ -39,7 +38,7 @@ export default {
                 return
             }
             // find the agents for crew quarters and greenhouse
-            const agents = this.gameConfig.agents
+            const {agents} = this.gameConfig
             const cq_type = Object.keys(agents).find(key => key.startsWith('crew_habitat'))
             const gh_type = Object.keys(agents).find(key => key.startsWith('greenhouse'))
             // loop through them and get co2 and o2 values
@@ -56,11 +55,6 @@ export default {
                 data[`O₂ ${label}`] = `${o2_perc.toFixed(2)}%`
             })
             this.activeData = data
-        },
-        stringFormatter: StringFormatter,
-        getLabel(currency) {
-            const desc = this.currencyDict[currency]
-            return desc ? desc.label : currency
         },
     },
 }

--- a/src/components/panels/AtmosphericValues.vue
+++ b/src/components/panels/AtmosphericValues.vue
@@ -1,0 +1,71 @@
+<template>
+    <section class="panel-dl-wrapper">
+        <CardList :data="activeData" />
+    </section>
+</template>
+
+
+<script>
+import {storeToRefs} from 'pinia'
+import {useDashboardStore} from '../../store/modules/DashboardStore'
+import {StringFormatter} from '../../javascript/utils'
+import {CardList} from '../basepanel'
+
+export default {
+    panelTitle: 'Atmospheric Values',
+    components: {
+        CardList,
+    },
+    modes: ['sim'],
+    setup() {
+        const dashboard = useDashboardStore()
+        const {humanAtmosphere, currentStepBuffer, currencyDict, gameConfig} = storeToRefs(dashboard)
+        const {getData, getUnit} = dashboard
+        return {humanAtmosphere, currentStepBuffer, getData, currencyDict, gameConfig, getUnit}
+    },
+    data() {
+        return {
+            activeData: {},
+        }
+    },
+    watch: {
+        currentStepBuffer(step) {
+            this.setActiveData(step)
+        },
+    },
+    methods: {
+        setActiveData(step) {
+            if (!step) {
+                return
+            }
+            // find the agents for crew quarters and greenhouse
+            const agents = this.gameConfig.agents
+            const cq_type = Object.keys(agents).find(key => key.startsWith('crew_habitat'))
+            const gh_type = Object.keys(agents).find(key => key.startsWith('greenhouse'))
+            // loop through them and get co2 and o2 values
+            const data = {}
+            const storages = [[cq_type, 'crew hab'], [gh_type, 'greenhouse']]
+            storages.forEach(([storage, label]) => {
+                if (!storage) return  // skip storage if it's not defined
+                const tot_atmo = this.getData([storage, 'storage', 'SUM', 1])
+                const co2_kg = this.getData([storage, 'storage', 'co2', step])
+                const co2_ppm = Math.round(co2_kg / tot_atmo * 1000000)
+                data[`CO₂ ${label}`] = `${co2_ppm}ppm`
+                const o2_kg = this.getData([storage, 'storage', 'o2', step])
+                const o2_perc = o2_kg / tot_atmo * 100
+                data[`O₂ ${label}`] = `${o2_perc.toFixed(2)}%`
+            })
+            this.activeData = data
+        },
+        stringFormatter: StringFormatter,
+        getLabel(currency) {
+            const desc = this.currencyDict[currency]
+            return desc ? desc.label : currency
+        },
+    },
+}
+</script>
+
+
+<style lang="scss" scoped>
+</style>


### PR DESCRIPTION
This PR adds two things:
* a `CardList` panel type, which displays numeric data as a list of "cards";
* an Atmospheric Values panel, that uses the `CardList` to display info about:
  * Crew quarters CO2/O2
  * Greenhouse CO2/O2

This is how the panel looks like, next to the Atmospheric monitors:
![image](https://github.com/user-attachments/assets/c781099c-e52a-4bf2-be74-82cc425fc676)
