### PR TITLE
Fix deps.inline vitest warning

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -61,8 +61,10 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'happy-dom',
-        deps: {
-            inline: ['vuetify'],
+        server: {
+            deps: {
+                inline: ['vuetify'],
+            },
         },
     },
 })


### PR DESCRIPTION
This PR fixes the following warning seen while running `npm run test`:
```
Vitest  "deps.inline" is deprecated. If you rely on vite-node directly,
use "server.deps.inline" instead. Otherwise, consider using "deps.optimizer.web.include"
```