### PR TITLE
Revert `pinia` to 2.2.4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "idle-js": "^1.2.0",
         "json-loader": "^0.5.7",
         "lodash": "^4.17.21",
-        "pinia": "^2.3.0",
+        "pinia": "^2.2.4",
         "postcss-nesting": "^13.0.1",
         "socket.io-client": "^4.8.1",
         "three": "^0.171.0",
@@ -32,7 +32,7 @@
         "vuetify": "^3.7.6"
       },
       "devDependencies": {
-        "@pinia/testing": "^0.1.7",
+        "@pinia/testing": "^0.1.6",
         "@vue/eslint-config-airbnb": "^8.0.0",
         "@vue/test-utils": "^2.4.6",
         "eslint": "^8.57.1",
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@pinia/testing": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-0.1.7.tgz",
-      "integrity": "sha512-xcDq6Ry/kNhZ5bsUMl7DeoFXwdume1NYzDggCiDUDKoPQ6Mo0eH9VU7bJvBtlurqe6byAntWoX5IhVFqWzRz/Q==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-0.1.6.tgz",
+      "integrity": "sha512-Q40s3kpjXpjmcnc61l84wyG83yVmkBi5rRdSoPpwQoRfSnNKKr52XjFFt6hP8iBxehYS9NR+D57T1uzgnEVPHg==",
       "dev": true,
       "dependencies": {
         "vue-demi": "^0.14.10"
@@ -979,7 +979,7 @@
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "pinia": ">=2.2.6"
+        "pinia": ">=2.2.3"
       }
     },
     "node_modules/@pinia/testing/node_modules/vue-demi": {
@@ -4715,9 +4715,9 @@
       }
     },
     "node_modules/pinia": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.0.tgz",
-      "integrity": "sha512-ohZj3jla0LL0OH5PlLTDMzqKiVw2XARmC1XYLdLWIPBMdhDW/123ZWr4zVAhtJm+aoSkFa13pYXskAvAscIkhQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.4.tgz",
+      "integrity": "sha512-K7ZhpMY9iJ9ShTC0cR2+PnxdQRuwVIsXDO/WIEV/RnMC/vmSoKDTKW/exNQYPI+4ij10UjXqdNiEHwn47McANQ==",
       "dependencies": {
         "@vue/devtools-api": "^6.6.3",
         "vue-demi": "^0.14.10"
@@ -4726,10 +4726,14 @@
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
         "typescript": ">=4.4.4",
-        "vue": "^2.7.0 || ^3.5.11"
+        "vue": "^2.6.14 || ^3.3.0"
       },
       "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
         "typescript": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "idle-js": "^1.2.0",
     "json-loader": "^0.5.7",
     "lodash": "^4.17.21",
-    "pinia": "^2.3.0",
+    "pinia": "^2.2.4",
     "postcss-nesting": "^13.0.1",
     "socket.io-client": "^4.8.1",
     "three": "^0.171.0",
@@ -34,7 +34,7 @@
     "vuetify": "^3.7.6"
   },
   "devDependencies": {
-    "@pinia/testing": "^0.1.7",
+    "@pinia/testing": "^0.1.6",
     "@vue/eslint-config-airbnb": "^8.0.0",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^8.57.1",


### PR DESCRIPTION
This is a follow-up of:
* #844 
* #878 
* #888 

Apparently even with 2.3.0 there are issues.  When reaching the dashboard on a non-preset simulation somehow the store breaks and the back button, top-right menu, and some panels don't work.  Everything seems to work with the presets.

I spent some time investigating the issue and couldn't figure out why it happens.  One of the errors I got was `value is undefined` referring to [this line in the `storeToRefs` definition](https://github.com/vuejs/pinia/blob/2071db285569a3119cf62c5be16a63fb7b681b1d/packages/pinia/src/storeToRefs.ts#L105).  I did some debugging but on my end everything looked ok, so it might simply be a bug in Pinia.

I'm going to revert back to 2.2.4 (all later versions are broken in different ways) and wait for a new release that hopefully fixes the issue.