### PR TITLE
Remove obsolete `eslint-disable-next-line` directives

### DIFF
--- a/src/components/panels/InhabitantsStatus.vue
+++ b/src/components/panels/InhabitantsStatus.vue
@@ -172,7 +172,7 @@ export default {
         attempt_read(func) {
             try {
                 return func()
-            } catch (error) {
+            } catch {
                 return '[loading data...]'
             }
         },

--- a/src/javascript/parseData.js
+++ b/src/javascript/parseData.js
@@ -76,7 +76,6 @@ export const parseData = (data, path) => {
             const indices = index.split(',').map(i => i.trim())
             if (indices.length > 0) {
                 const output = {}
-                // eslint-disable-next-line no-restricted-syntax
                 for (const i of indices) {
                     const res = parseData(data[i], remainder)
                     if (res !== null) {

--- a/src/threejs/World.vue
+++ b/src/threejs/World.vue
@@ -96,14 +96,11 @@ export default {
             camera = buildCamera()
             renderer = buildRenderer(this.containerId, this.settings)
             loader = new Loader(this.settings, this.showLoadingScreen)
-
-            // eslint-disable-next-line no-new
             this.resizer = new Resizer(camera, renderer, this.addHookup, this.$refs.sceneContainer)
             buildControls(camera, renderer.domElement, this.settings, this.addTick)
             buildLights(this.settings, scene)
             buildSkybox(scene, this.settings)
             if (this.settings.stats) {
-                // eslint-disable-next-line no-new
                 new StatsBox(this.containerId, this.addTick)
             }
         },

--- a/src/threejs/systems/loader.js
+++ b/src/threejs/systems/loader.js
@@ -23,7 +23,6 @@ class Loader {
     }
 
     async loadModel(assetName, place) {
-        // eslint-disable-next-line prefer-template
         const asset = await import(`../../assets/models/${assetName}.glb`)
         let model = await this.loader.loadAsync(asset.default)
         model = model.scene
@@ -72,7 +71,6 @@ class Loader {
         return model
     }
 
-    // eslint-disable-next-line class-methods-use-this
     clearCache(layout) {
         // Remove items from cache which are not part of current layout
         // Technically it doesn't need to be a method of loader as it doesn't

--- a/src/threejs/systems/skybox.js
+++ b/src/threejs/systems/skybox.js
@@ -7,13 +7,11 @@ const buildSkybox = async(scene, settings) => {
     await Promise.all([...angles, 'ground'].map(async angle => {
         // image source: https://opengameart.org/content/mayhems-skyboxes-more
         // ref: (acdcjunior's answer) https://stackoverflow.com/a/49080214
-        // eslint-disable-next-line prefer-template
         const image = await import(`../../assets/skybox/${angle}.jpg`)
         images[angle] = image.default
     }))
 
     // Add the skybox
-    // eslint-disable-next-line vue/no-mutating-props
     scene.background = new THREE.CubeTextureLoader()
             .load(angles.map(angle => images[angle]))
 

--- a/src/views/ConfigurationView.vue
+++ b/src/views/ConfigurationView.vue
@@ -174,7 +174,6 @@ export default {
             // 10ms seem to be enough to give time to Vue to see the change
             // but it's not 100% reliable.  I couldn't find a way to make
             // it work reliably with await this.$nextTick()
-            // eslint-disable-next-line no-promise-executor-return
             await new Promise(r => setTimeout(r, 10))  // await for 10ms
 
             // load cached simdata if the user selects a preset


### PR DESCRIPTION
This PR removes obsolete `eslint-disable-next-line` directives that cause warnings with ESLint 9, as seen in:
* #907 

It also fixes an error about an unused variable (ironically called `error`).