### PR TITLE
Expect UTC timestamp from live backend

### DIFF
--- a/src/components/panels/Sensors.vue
+++ b/src/components/panels/Sensors.vue
@@ -82,7 +82,7 @@ export default {
                 if (reading[0] === sensorId) {
                     Object.entries(reading[1]).forEach(item => {
                         if (item[0] === itemName) {
-                            value = item[1].toFixed(2)
+                            value = item[1]?.toFixed(2) ?? '-'
                         }
                     })
                 }

--- a/src/store/modules/LiveStore.js
+++ b/src/store/modules/LiveStore.js
@@ -63,16 +63,16 @@ export const useLiveStore = defineStore('LiveStore', {
         },
         /** Sets the timestamp for each bundleNum 'n' and splitting it into a date and
          *  time dict—received with timestamp[n].date and timestamp[n].time.
+         *  The timestamp is received as UTC and converted to local time.
          */
         setTimestamp(value) {
             const {n: bundle_n} = value
             const {timestamp: t} = value
 
-            const dateTime = t.split(' ')
-            this.timestamp[bundle_n - this.initBundleNum] = {
-                date: dateTime[0],
-                time: dateTime[1].split('.')[0],  // Remove milliseconds from time
-            }
+            const local = new Date(t)
+            const date = local.toLocaleDateString('en-CA')  // YYYY-MM-DD
+            const time = local.toLocaleTimeString('en-GB')  // HH:MM:SS
+            this.timestamp[bundle_n - this.initBundleNum] = {date, time}
         },
         /** Sets the data bundles array, pushing all bundles—composed of bundleNum 'n',
          *  readings object, and timestamp—received by the client.


### PR DESCRIPTION
This PR updates the `setTimestamp` method in `LiveStore` to expect UTC timestamps from the live backend and to convert them to local time after the changes introduced in:
* https://github.com/overthesun/simoc-sam/pull/391

After both PRs are merged, the user will keep seeing local timestamps in the charts like before.

This PR also fixed a minor bug while handling `null` values.